### PR TITLE
Setup emulator refactor

### DIFF
--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ def dump_threads(*args):
     Helpful signal handler for debugging threads
     """
 
-    logger.debug('\nSIGUSR received, dumping threads\n')
+    logger.critical('\nSIGUSR received, dumping threads\n')
     for th in threading.enumerate():
         logger.critical(th)
         log = traceback.extract_stack(sys._current_frames()[th.ident])

--- a/main.py
+++ b/main.py
@@ -143,9 +143,9 @@ def dump_threads(*args):
 
     logger.debug('\nSIGUSR received, dumping threads\n')
     for th in threading.enumerate():
-        logger.debug(th)
+        logger.critical(th)
         log = traceback.extract_stack(sys._current_frames()[th.ident])
-        logger.debug(log)
+        logger.critical(log)
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from apps.app_manager import AppManager
 from helpers import read_config, local_path_gen
 from input import input
 from output import output
-from ui import Printer, Menu
+from ui import Printer
 
 emulator_flag_filename = "emulator"
 local_path = local_path_gen(__name__)
@@ -27,6 +27,7 @@ logging_format = (
 
 config_paths = ['/boot/zpui_config.json'] if not is_emulator else []
 config_paths.append(local_path('config.json'))
+
 
 def init():
     """Initialize input and output objects"""
@@ -124,7 +125,7 @@ def exception_wrapper(callback, i, o):
         status = 1
     except:
         logging.exception('A wild exception appears!')
-        logging.exception(format_exc())
+        logging.exception(traceback.format_exc())
         Printer(["A wild exception", "appears!"], None, o, 0)
         status = 1
     else:
@@ -140,11 +141,11 @@ def dump_threads(*args):
     Helpful signal handler for debugging threads
     """
 
-    print('\nSIGUSR received, dumping threads\n')
+    logger.debug('\nSIGUSR received, dumping threads\n')
     for th in threading.enumerate():
-        print(th)
-        traceback.print_stack(sys._current_frames()[th.ident])
-        print('')
+        logger.debug(th)
+        log = traceback.extract_stack(sys._current_frames()[th.ident])
+        logger.debug(log)
 
 
 if __name__ == '__main__':

--- a/setup_emulator
+++ b/setup_emulator
@@ -31,3 +31,4 @@ if __name__ == '__main__':
     create_file('apps/phone/do_not_load')
     create_file('apps/flashlight/do_not_load')
     create_file('apps/hardware_apps/do_not_load')
+    create_file('apps/test_hardware/do_not_load')

--- a/setup_emulator
+++ b/setup_emulator
@@ -7,10 +7,8 @@ from helpers import (read_config, write_config)
 CONFIG_PATH = 'config.json'
 
 
-def touch(filename):
-    if os.path.exists(filename):
-        os.utime(filename, None)
-    else:
+def create_file(filename):
+    if not os.path.exists(filename):
         open(filename, 'a').close()
 
 
@@ -30,8 +28,6 @@ if __name__ == '__main__':
     # In the future, the modem could be emulated.
     # Until then, the app will likely have to be
     # disabled on emulators
-    touch('apps/phone/do_not_load')
-    touch('apps/phone/do_not_load')
-    touch('apps/flashlight/do_not_load')
-    touch('apps/hardware_apps/do_not_load')
-    touch('apps/hardware_apps/do_not_load')
+    create_file('apps/phone/do_not_load')
+    create_file('apps/flashlight/do_not_load')
+    create_file('apps/hardware_apps/do_not_load')

--- a/setup_emulator
+++ b/setup_emulator
@@ -1,27 +1,37 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
-import subprocess
+import os
 
 from helpers import (read_config, write_config)
 
 CONFIG_PATH = 'config.json'
 
-try:
-    config = read_config(CONFIG_PATH)
-except:
-    config = dict()
 
-config['input'] = [{'driver': 'pygame_input'}]
-config['output'] = [{"driver": "pygame_emulator"}]
+def touch(filename):
+    if os.path.exists(filename):
+        os.utime(filename, None)
+    else:
+        open(filename, 'a').close()
 
-write_config(config, CONFIG_PATH)
 
-# Phone app will try to connect to a modem.
-# The emulator environment is unlikely to have one
-# In the future, the modem could be emulated.
-# Until then, the app will likely have to be 
-# disabled on emulators
-subprocess.call('touch apps/phone/do_not_load'.split())
-subprocess.call('touch apps/flashlight/do_not_load'.split())
-subprocess.call('touch apps/hardware_apps/do_not_load'.split())
-subprocess.call('touch apps/hardware_test/do_not_load'.split())
+if __name__ == '__main__':
+    try:
+        config = read_config(CONFIG_PATH)
+    except:
+        config = dict()
+
+    config['input'] = [{'driver': 'pygame_input'}]
+    config['output'] = [{"driver": "pygame_emulator"}]
+
+    write_config(config, CONFIG_PATH)
+
+    # Phone app will try to connect to a modem.
+    # The emulator environment is unlikely to have one
+    # In the future, the modem could be emulated.
+    # Until then, the app will likely have to be
+    # disabled on emulators
+    touch('apps/phone/do_not_load')
+    touch('apps/phone/do_not_load')
+    touch('apps/flashlight/do_not_load')
+    touch('apps/hardware_apps/do_not_load')
+    touch('apps/hardware_apps/do_not_load')


### PR DESCRIPTION
setup_emulator.py:
- uses python2
- avoids unecessary usage of subprocess.call()
- fixes wrong name 'hardware_test' -> 'hardware_apps'
- uses if __name__=='__main__'

main.py:
-PEP8 formatting
-uses logging instead of printer to dump threads