### PR TITLE
[OK]Loading screen

### DIFF
--- a/apps/example_apps/loadingbar_test_app/main.py
+++ b/apps/example_apps/loadingbar_test_app/main.py
@@ -1,5 +1,6 @@
 from apps.zero_app import ZeroApp
-from ui.loading_indicators import ProgressBar
+from ui import Menu
+from ui.loading_indicators import TextProgressBar, IdleThrobber, CircularProgressIndicator
 
 
 class LoadingBarExampleApp(ZeroApp):
@@ -7,10 +8,10 @@ class LoadingBarExampleApp(ZeroApp):
         super(LoadingBarExampleApp, self).__init__(i, o)
         self.menu_name = "Loading test APP"
 
-        self.loading_screen = ProgressBar(self.i, self.o, refresh_interval=.1, show_percentage=True)
+        self.loading_screen = CircularProgressIndicator(self.i, self.o, refresh_interval=.1, show_percentage=True)
+        # self.loading_screen = IdleThrobber(self.i, self.o, refresh_interval=.1, show_percentage=True)
         # todo: uncomment line below to test another indicator
         # self.loading_screen = DottedProgressIndicator(self.i, self.o, refresh_interval=.1, show_percentage=True)
-
         self.loading_screen.keymap['KEY_RIGHT'] = self.increase_progress
 
     def increase_progress(self):

--- a/apps/example_apps/loadingbar_test_app/main.py
+++ b/apps/example_apps/loadingbar_test_app/main.py
@@ -1,52 +1,38 @@
 from time import sleep
 from apps.zero_app import ZeroApp
-from ui import Menu
-from ui.loading_indicators import TextProgressBar, IdleThrobber, CircularProgressIndicator
+from ui import ProgressTextBar, ProgressCircular, IdleDottedMessage, IdleCircular, Listbox
 
-from ui import ProgressBar, DottedProgressIndicator, Listbox
 
 class LoadingBarExampleApp(ZeroApp):
     def __init__(self, i, o):
         super(LoadingBarExampleApp, self).__init__(i, o)
         self.menu_name = "Loading bar test app"
 
-        self.loading_screen = CircularProgressIndicator(self.i, self.o, refresh_interval=.1, show_percentage=True, keymap={"KEY_RIGHT":self.increase_progress})
-        # self.loading_screen = IdleThrobber(self.i, self.o, refresh_interval=.1, show_percentage=True)
-        # todo: uncomment line below to test another indicator
-        # self.loading_screen = DottedProgressIndicator(self.i, self.o, refresh_interval=.1, show_percentage=True)
-        self.loading_screen.keymap['KEY_RIGHT'] = self.increase_progress
-        lb_contents = [["Progress bar", self.progress_bar],
-                       ["Dotted bar", self.dotted_progress_bar]]
+        self.text_progress = ProgressTextBar(self.i, self.o, refresh_interval=.1, show_percentage=True,
+                                             percentage_offset=0)
+        self.circular_progress = ProgressCircular(self.i, self.o, show_percentage=True)
+        self.dotted_progress_bar = IdleDottedMessage(self.i, self.o, refresh_interval=.1)
+        self.throbber = IdleCircular(self.i, self.o, refresh_interval=.1)
+        lb_contents = [
+            ["Text progress bar", self.text_progress],
+            ["Dotted idle ", self.dotted_progress_bar],
+            ["Circular progress ", self.circular_progress],
+            ["Idle Throbber", self.throbber],
+        ]
         self.bar_choice_listbox = Listbox(lb_contents, self.i, self.o)
-        self.progress_bar = ProgressBar(self.i, self.o,
-                                          refresh_interval=.1,
-                                          show_percentage=True,
-                                          percentage_offset=0,
-                                          keymap={"KEY_RIGHT":self.increase_progress})
-
-        self.dotted_progress_bar = DottedProgressIndicator(self.i, self.o,
-                                                       refresh_interval=.1)
-
-        lb_contents = [["Progress bar", self.progress_bar],
-                       ["Dotted bar", self.dotted_progress_bar]]
-        self.bar_choice_listbox = Listbox(lb_contents, self.i, self.o)
-
-    def increase_progress(self):
-        self.loading_screen.progress += .05
 
     def on_start(self):
         super(LoadingBarExampleApp, self).on_start()
         chosen_loading_bar = self.bar_choice_listbox.activate()
         chosen_loading_bar.run_in_background()
-        if isinstance(chosen_loading_bar, ProgressBar):
+        if hasattr(chosen_loading_bar, "progress"):
             for i in range(101):
-                chosen_loading_bar.progress = float(i)/100
-                sleep(0.1)
-            sleep(2)
+                chosen_loading_bar.progress = float(i) / 100
+                sleep(0.01)
+            sleep(1)
             for i in range(101)[::-1]:
-                chosen_loading_bar.progress = float(i)/100
-                sleep(0.1)
+                chosen_loading_bar.progress = float(i) / 100
+                sleep(0.01)
         else:
             sleep(3)
             chosen_loading_bar.deactivate()
-

--- a/apps/example_apps/loadingbar_test_app/main.py
+++ b/apps/example_apps/loadingbar_test_app/main.py
@@ -1,8 +1,8 @@
 from time import sleep
 
 from apps.zero_app import ZeroApp
-from ui import ProgressTextBar, ProgressCircular, IdleDottedMessage, IdleCircular, Listbox
-from ui.loading_indicators import GraphicalLoadingBar
+from ui import TextProgressBar, CircularProgressBar, IdleDottedMessage, Throbber, Listbox
+from ui.loading_indicators import ProgressBar
 
 
 class LoadingBarExampleApp(ZeroApp):
@@ -10,12 +10,12 @@ class LoadingBarExampleApp(ZeroApp):
         super(LoadingBarExampleApp, self).__init__(i, o)
         self.menu_name = "Loading bar test app"
 
-        self.text_progress = ProgressTextBar(self.i, self.o, refresh_interval=.1, show_percentage=True,
+        self.text_progress = TextProgressBar(self.i, self.o, refresh_interval=.1, show_percentage=True,
                                              percentage_offset=0)
-        self.circular_progress = ProgressCircular(self.i, self.o, show_percentage=True)
+        self.circular_progress = CircularProgressBar(self.i, self.o, show_percentage=True)
         self.dotted_progress_bar = IdleDottedMessage(self.i, self.o, refresh_interval=.1)
-        self.throbber = IdleCircular(self.i, self.o, refresh_interval=.1)
-        self.progress_bar = GraphicalLoadingBar(self.i, self.o, refresh_interval=.1)
+        self.throbber = Throbber(self.i, self.o, refresh_interval=.1)
+        self.progress_bar = ProgressBar(self.i, self.o, refresh_interval=.1)
         lb_contents = [
             ["Text progress bar", self.text_progress],
             ["Dotted idle ", self.dotted_progress_bar],

--- a/apps/example_apps/loadingbar_test_app/main.py
+++ b/apps/example_apps/loadingbar_test_app/main.py
@@ -1,6 +1,8 @@
 from time import sleep
+
 from apps.zero_app import ZeroApp
 from ui import ProgressTextBar, ProgressCircular, IdleDottedMessage, IdleCircular, Listbox
+from ui.loading_indicators import GraphicalLoadingBar
 
 
 class LoadingBarExampleApp(ZeroApp):
@@ -13,11 +15,13 @@ class LoadingBarExampleApp(ZeroApp):
         self.circular_progress = ProgressCircular(self.i, self.o, show_percentage=True)
         self.dotted_progress_bar = IdleDottedMessage(self.i, self.o, refresh_interval=.1)
         self.throbber = IdleCircular(self.i, self.o, refresh_interval=.1)
+        self.progress_bar = GraphicalLoadingBar(self.i, self.o, refresh_interval=.1)
         lb_contents = [
             ["Text progress bar", self.text_progress],
             ["Dotted idle ", self.dotted_progress_bar],
             ["Circular progress ", self.circular_progress],
             ["Idle Throbber", self.throbber],
+            ["Graphical Loading bar", self.progress_bar],
         ]
         self.bar_choice_listbox = Listbox(lb_contents, self.i, self.o)
 
@@ -32,7 +36,7 @@ class LoadingBarExampleApp(ZeroApp):
             sleep(1)
             for i in range(101)[::-1]:
                 chosen_loading_bar.progress = float(i) / 100
-                sleep(0.01)
+                sleep(0.1)
         else:
             sleep(3)
             chosen_loading_bar.deactivate()

--- a/apps/stopwatch/main.py
+++ b/apps/stopwatch/main.py
@@ -2,14 +2,14 @@
 
 from apps.zero_app import ZeroApp
 from ui import Refresher
-from ui.utils import Counter
+from ui.utils import Chronometer
 
 
 class StopwatchApp(ZeroApp):
     def __init__(self, i, o):
         super(StopwatchApp, self).__init__(i, o)
         self.menu_name = "Stopwatch"
-        self.counter = Counter()
+        self.counter = Chronometer()
         self.refresher = None
         self.__instructions = ["", "UP/ENTER to start/pause", "RIGHT : restart", "DOWN : reset"]
 

--- a/apps/stopwatch/main.py
+++ b/apps/stopwatch/main.py
@@ -1,63 +1,8 @@
 # coding=utf-8
-from time import time
 
 from apps.zero_app import ZeroApp
 from ui import Refresher
-
-
-class Chronometer(object):
-    def __init__(self):
-        self.__active = False
-        self.__last_call = time()
-
-    def tick(self):
-        """
-        :rtype: int
-        :return: the time elapsed since the previous tick
-        """
-        now = time()
-        elapsed = now - self.__last_call
-        self.__last_call = now
-        return elapsed
-
-
-class Counter(object):
-    def __init__(self):
-        self.__active = False
-        self.__cron = Chronometer()
-        self.__elapsed = 0
-
-    @property
-    def active(self):
-        return self.__active
-
-    @property
-    def elapsed(self):
-        return self.__elapsed
-
-    def update(self):
-        if not self.__active:
-            return
-        self.__elapsed += self.__cron.tick()
-
-    def stop(self):
-        self.__cron.tick()
-        self.__elapsed = 0
-        self.__active = False
-
-    def pause(self):
-        self.__active = False
-
-    def resume(self):
-        self.__cron.tick()
-        self.__active = True
-
-    def start(self):
-        self.stop()
-        self.resume()
-
-    def toggle(self):
-        self.pause() if self.active else self.resume()
+from ui.utils import Counter
 
 
 class StopwatchApp(ZeroApp):

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -10,6 +10,7 @@ from path_picker import PathPicker
 from printer import Printer, PrettyPrinter, GraphicsPrinter
 from refresher import Refresher
 from ui.numbered_menu import NumberedMenu
-from ui.loading_indicators import ProgressBar, DottedProgressIndicator
+from ui.loading_indicators import TextProgressBar, DottedIdleIndicator, ProgressIndicator, LoadingIndicator, \
+    CircularProgressIndicator
 
 IntegerInDecrementInput = IntegerAdjustInput  # Compatibility with old ugly name

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -10,7 +10,7 @@ from path_picker import PathPicker
 from printer import Printer, PrettyPrinter, GraphicsPrinter
 from refresher import Refresher
 from ui.numbered_menu import NumberedMenu
-from ui.loading_indicators import TextProgressBar, DottedIdleIndicator, ProgressIndicator, LoadingIndicator, \
-    CircularProgressIndicator
+from ui.loading_indicators import ProgressTextBar, IdleDottedMessage, ProgressIndicator, LoadingIndicator, \
+    ProgressCircular, IdleCircular
 
 IntegerInDecrementInput = IntegerAdjustInput  # Compatibility with old ugly name

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -9,8 +9,8 @@ from numpad_input import NumpadCharInput, NumpadNumberInput
 from path_picker import PathPicker
 from printer import Printer, PrettyPrinter, GraphicsPrinter
 from refresher import Refresher
+from ui.loading_indicators import TextProgressBar, IdleDottedMessage, ProgressIndicator, LoadingIndicator, \
+    CircularProgressBar, Throbber, ProgressBar
 from ui.numbered_menu import NumberedMenu
-from ui.loading_indicators import ProgressTextBar, IdleDottedMessage, ProgressIndicator, LoadingIndicator, \
-    ProgressCircular, IdleCircular
 
 IntegerInDecrementInput = IntegerAdjustInput  # Compatibility with old ugly name

--- a/ui/base_list_ui.py
+++ b/ui/base_list_ui.py
@@ -3,11 +3,13 @@ Best example of such an element is a Menu element - it has menu entries you can 
 
 import logging
 from copy import copy
-from time import sleep
-from PIL import ImageFont
 from threading import Event
-from utils import to_be_foreground, clamp, clamp_list_index
+from time import sleep
+
+from PIL import ImageFont
 from luma.core.render import canvas as luma_canvas
+
+from utils import to_be_foreground, clamp_list_index
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
@@ -600,7 +602,7 @@ class MainMenuTripletView(SixteenPtView):
     charheight = 16
     
     def __init__(self, *args, **kwargs):
-        PrettyGraphicalView.__init__(self, *args, **kwargs)
+        SixteenPtView.__init__(self, *args, **kwargs)
         self.charheight = self.o.height / 3
 
     @to_be_foreground

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -1,14 +1,15 @@
 from __future__ import division
 
+import math
 from math import cos
+from threading import Thread
 from time import time
 
-import math
 from PIL import ImageDraw
 from luma.core.render import canvas
+
 from ui import Refresher
 from ui.utils import clamp, Counter
-from threading import Thread
 
 """
 These classes subclass `Refresher` to show an animated screen.
@@ -158,15 +159,6 @@ class ProgressTextBar(ProgressIndicator):
 
     def get_progress_percentage(self):
         return '{}%'.format(self.progress * 100)
-
-    @property
-    def progress(self):
-        return float(self._progress)
-
-    @progress.setter
-    def progress(self, value):
-        self._progress = clamp(value, 0, 1)
-        self.refresh()
 
     def get_progress_percentage_string(self):
         return '{}%'.format(int(self.progress * 100))

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -10,7 +10,7 @@ from PIL import ImageDraw
 from luma.core.render import canvas
 
 from ui import Refresher
-from ui.utils import clamp, Counter
+from ui.utils import clamp, Counter, to_be_foreground
 
 """
 These classes subclass `Refresher` to show an animated screen.
@@ -96,6 +96,7 @@ class Throbber(LoadingIndicator):
         self.counter.start()
         return Refresher.activate(self)
 
+    @to_be_foreground
     def refresh(self):
         self.update_throbber_angle()
         c = canvas(self.o.device)

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -1,17 +1,122 @@
+from __future__ import division
+
+from math import cos
+from time import time
+
+import math
+from PIL import ImageDraw
+from luma.core.render import canvas
 from ui import Refresher
-from ui.utils import clamp
+from ui.utils import clamp, Counter
+
+"""
+These classes subclass `Refresher` to show an animated screen.
+Those screens are used to show the user something is happening in the background.
+
+There are two possibility : either you know how much work is happening in the background, or you don't.
+
+Vocabulary:
+*Idle* word is used for classes that don't know how much processing is left to do
+Example : throbber, dotted loading screen
+*Progress* word is used for classes that know how much work is done and how much work is left.
+Progress classes have a property `progress` that is used by the app programmer to indicate the advancement
+of the task. (range [0-1])
+
+"""
 
 
 class LoadingIndicator(Refresher):
-
     def __init__(self, i, o, *args, **kwargs):
         Refresher.__init__(self, self.on_refresh, i, o)
+        self._progress = 0
 
     def on_refresh(self):
         pass
 
 
-class DottedProgressIndicator(LoadingIndicator):
+class ProgressIndicator(LoadingIndicator):
+
+    @property
+    def progress(self):
+        return float(self._progress)
+
+    @progress.setter
+    def progress(self, value):
+        self._progress = clamp(value, 0, 1)
+        self.refresh()  # doesn't work ? todo : check out why
+
+
+class CenteredTextRenderer(object):
+    def draw_centered_text(self, draw, content, device_size):
+        # type: (ImageDraw, str, tuple) -> None
+        w, h = draw.textsize(content)
+        dw, dh = device_size
+        coords = (dw / 2 - w / 2, dh / 2 - h / 2)
+        draw.text(coords, content, fill=True)
+
+
+class IdleThrobber(LoadingIndicator):
+
+    def __init__(self, i, o, *args, **kwargs):
+        LoadingIndicator.__init__(self, i, o, *args, **kwargs)
+        self.refresh_interval = 0.01
+        self._current_angle = 0
+        self._current_range = 0  # range or width of the throbber
+        self.rotation_speed = 360  # degree per second
+        self.counter = Counter()  # We use a counter to make the animation independent of the refresh-rate
+        self.start_time = 0
+
+    def activate(self):
+        self.start_time = time()
+        self.counter.start()
+        return Refresher.activate(self)
+
+    def refresh(self):
+        self.update_throbber_angle()
+        c = canvas(self.o.device)
+        c.__enter__()
+        x, y = c.device.size
+        radius = min(x, y) / 4
+        draw = c.draw
+        draw.arc(
+            (
+                x / 2 - radius, y / 2 - radius,
+                x / 2 + 1 + radius, y / 2 + radius
+            ),
+            start=(self._current_angle - self._current_range / 2) % 360,
+            end=(self._current_angle + self._current_range / 2) % 360,
+            fill=True
+        )
+        self.o.display_image(c.image)
+
+    def update_throbber_angle(self):
+        self.counter.update()
+        self._current_angle += self.rotation_speed * self.counter.elapsed
+        time_since_activation = time() - self.start_time
+        self._current_range = cos(time_since_activation * math.pi) / 2 + 0.5
+        self._current_range = (self._current_range * 170) + 10
+        self.counter.restart()
+
+
+class CircularProgressIndicator(ProgressIndicator, CenteredTextRenderer):
+
+    def __init__(self, i, o, *args, **kwargs):
+        LoadingIndicator.__init__(self, i, o, *args, **kwargs)
+
+    def refresh(self):
+        c = canvas(self.o.device)
+        c.__enter__()
+        x, y = c.device.size
+        radius = min(x, y) / 4
+        draw = c.draw
+        center_coordinates = (x / 2 - radius, y / 2 - radius, x / 2 + radius, y / 2 + radius)
+        draw.arc(center_coordinates, start=0, end=360 * self.progress, fill=True)
+        self.draw_centered_text(draw, "{:.0%}".format(self.progress), self.o.device.size)
+
+        self.o.display_image(c.image)
+
+
+class DottedIdleIndicator(LoadingIndicator):
 
     def __init__(self, i, o, *args, **kwargs):
         LoadingIndicator.__init__(self, i, o, *args, **kwargs)
@@ -24,7 +129,7 @@ class DottedProgressIndicator(LoadingIndicator):
         return self.message + '.' * self.dot_count
 
 
-class ProgressBar(LoadingIndicator):
+class TextProgressBar(ProgressIndicator):
     def __init__(self, i, o, *args, **kwargs):
         LoadingIndicator.__init__(self, i, o, *args, **kwargs)
         self.message = kwargs.pop("message") if "message" in kwargs else "Loading"
@@ -33,14 +138,6 @@ class ProgressBar(LoadingIndicator):
         self.border_chars = kwargs.pop("border_chars") if "border_chars" in kwargs else "[]"
         self.show_percentage = kwargs.pop("show_percentage") if "show_percentage" in kwargs else False
         self._progress = 0  # 0-1 range
-
-    @property
-    def progress(self):
-        return float(self._progress)
-
-    @progress.setter
-    def progress(self, value):
-        self._progress = clamp(value, 0, 1)
 
     def get_progress_percentage(self):
         return '{}%'.format(self.progress * 100)

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -18,12 +18,6 @@ Those screens are used to show the user something is happening in the background
 
 There are two possibility : either you know how much work is happening in the background, or you don't.
 
-Vocabulary:
-*Idle* word is used for classes that don't know how much processing is left to do
-Example : throbber, dotted loading screen
-*Progress* word is used for classes that know how much work is done and how much work is left.
-Progress classes have a property `progress` that is used by the app programmer to indicate the advancement
-of the task. (range [0-1])
 
 """
 
@@ -47,7 +41,9 @@ class CenteredTextRenderer(object):
 
 
 class LoadingIndicator(Refresher):
-
+    """
+    Abstract class to indicate a loading time to the user
+    """
     def __init__(self, i, o, *args, **kwargs):
         Refresher.__init__(self, self.on_refresh, i, o)
         self._progress = 0
@@ -66,7 +62,10 @@ class LoadingIndicator(Refresher):
 
 
 class ProgressIndicator(LoadingIndicator):
-
+    """
+    Abstract class used to indicate a finite-time loading. Subclasses of
+    ProgressIndicator usually show a percentage of the progress done or left
+    """
     @property
     def progress(self):
         return float(self._progress)
@@ -78,7 +77,10 @@ class ProgressIndicator(LoadingIndicator):
 
 
 # =========================concrete classes=========================
-class IdleCircular(LoadingIndicator):
+class Throbber(LoadingIndicator):
+    """
+    A throbber is a circular LoadingIndicator. Usually used in website or Android.
+    """
 
     def __init__(self, i, o, *args, **kwargs):
         LoadingIndicator.__init__(self, i, o, *args, **kwargs)
@@ -122,7 +124,10 @@ class IdleCircular(LoadingIndicator):
 
 
 class IdleDottedMessage(LoadingIndicator):
-
+    """
+    A simple message to which dots are appended to show the user
+    something is happenning and the UI did not freeze.
+    """
     def __init__(self, i, o, *args, **kwargs):
         LoadingIndicator.__init__(self, i, o, *args, **kwargs)
         self.message = kwargs.pop("message") if "message" in kwargs else "Loading".center(o.cols).rstrip()
@@ -134,8 +139,9 @@ class IdleDottedMessage(LoadingIndicator):
         return self.message + '.' * self.dot_count
 
 
-class ProgressCircular(ProgressIndicator, CenteredTextRenderer):
-
+class CircularProgressBar(ProgressIndicator, CenteredTextRenderer):
+    """CircularProgressBar is half Throbber, half progressbar. Makes your app
+    look all sci-fi !"""
     def __init__(self, i, o, *args, **kwargs):
         self.show_percentage = kwargs.pop("show_percentage") if "show_percentage" in kwargs else True
         LoadingIndicator.__init__(self, i, o, *args, **kwargs)
@@ -154,7 +160,8 @@ class ProgressCircular(ProgressIndicator, CenteredTextRenderer):
         self.o.display_image(c.image)
 
 
-class ProgressTextBar(ProgressIndicator):
+class TextProgressBar(ProgressIndicator):
+    """Usual text-based fallback for a classical loading bar"""
     def __init__(self, i, o, *args, **kwargs):
         # We need to pop() these arguments instead of using kwargs.get() because they
         # have to be removed from kwargs to prevent TypeErrors
@@ -199,8 +206,11 @@ class ProgressTextBar(ProgressIndicator):
         return [self.message.center(self.o.cols), bar]
 
 
-class GraphicalLoadingBar(ProgressIndicator, CenteredTextRenderer):
-
+class ProgressBar(ProgressIndicator, CenteredTextRenderer):
+    """
+    The usual progress bar you would expect. Optionaly handles padding and margin
+    for some customization
+    """
     def __init__(self, i, o, *args, **kwargs):
         self.show_percentage = kwargs.pop("show_percentage") if "show_percentage" in kwargs else True
         self.margin = kwargs.pop("margin") if "margin" in kwargs else 15

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -45,7 +45,6 @@ class LoadingIndicator(Refresher):
     Abstract class to indicate a loading time to the user
     """
     def __init__(self, i, o, *args, **kwargs):
-        Refresher.__init__(self, self.on_refresh, i, o)
         self._progress = 0
         Refresher.__init__(self, self.on_refresh, i, o, *args, **kwargs)
         self.t = None

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -10,7 +10,7 @@ from PIL import ImageDraw
 from luma.core.render import canvas
 
 from ui import Refresher
-from ui.utils import clamp, Counter, to_be_foreground
+from ui.utils import clamp, Chronometer, to_be_foreground
 
 """
 These classes subclass `Refresher` to show an animated screen.
@@ -87,7 +87,7 @@ class Throbber(LoadingIndicator):
         self._current_angle = 0
         self._current_range = 0  # range or width of the throbber
         self.rotation_speed = 360  # degree per second
-        self.counter = Counter()  # We use a counter to make the animation independent of the refresh-rate
+        self.counter = Chronometer()  # We use a counter to make the animation independent of the refresh-rate
         self.start_time = 0
 
     def activate(self):

--- a/ui/refresher.py
+++ b/ui/refresher.py
@@ -1,7 +1,6 @@
+import logging
 from threading import Event
 from time import sleep
-from copy import copy
-import logging
 
 from ui.utils import to_be_foreground
 
@@ -9,7 +8,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
-class Refresher():
+class Refresher(object):
     """Implements a state where display is refreshed from time to time, updating the screen with information from a function.
     """
     refresh_function = None

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -1,6 +1,6 @@
 import logging
 from functools import wraps
-from time import time
+from time import time, sleep
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -52,49 +52,102 @@ def check_value_lock(func):
     return wrapper
 
 
-class Counter(object):
+class Chronometer(object):
+    """
+    This object measures time.
+    >>> cron = Chronometer()
+    >>> cron.active
+    False
+    >>> cron.start()
+    >>> cron.active
+    True
+    >>> sleep(1)
+    >>> cron.update()
+    >>> round(cron.elapsed)
+    1.0
+    >>> cron.pause()
+    >>> sleep(1)
+    >>> round(cron.elapsed)
+    1.0
+    >>> cron.toggle()  # or cron.resume()
+    >>> sleep(1)
+    >>> cron.update()
+    >>> round(cron.elapsed)
+    2.0
+    >>> cron.restart()
+    >>> sleep(1)
+    >>> cron.update()
+    >>> round(cron.elapsed)
+    1.0
+    """
     def __init__(self):
         self.__active = False
-        self.__cron = Chronometer()
+        self.__cron = Ticker()
         self.__elapsed = 0
 
     @property
     def active(self):
+        # type: () -> bool
+        """whether the Chronometer is counting time"""
         return self.__active
 
     @property
     def elapsed(self):
+        # type: () -> float
+        """returns the elapsed time"""
         return self.__elapsed
 
     def update(self):
+        # type: () -> None
+        """Updates the chronometer with the current time"""
         if not self.__active:
             return
         self.__elapsed += self.__cron.tick()
 
     def stop(self):
+        # type: () -> None
+        """Stop and resets the Chronometer"""
         self.__cron.tick()
         self.__elapsed = 0
         self.__active = False
 
     def pause(self):
+        # type: () -> None
+        """Pauses the Chronometer, but keeps the measured time so far"""
         self.__active = False
 
     def resume(self):
+        # type: () -> None
+        """Resumes measuring time after a pause"""
         self.__cron.tick()
         self.__active = True
 
     def start(self):
+        # type: () -> None
+        """Starts measuring time"""
         self.stop()
         self.resume()
 
     def toggle(self):
+        # type: () -> None
+        """Toggles between pause and resume"""
         self.pause() if self.active else self.resume()
 
     def restart(self):
+        # type: () -> None
+        """Resets the Chronometer and starts a new measure immediatly"""
         self.start()
 
 
-class Chronometer(object):
+class Ticker(object):
+    """
+    This object returns the time elapsed between two calls to it's `tick()` function
+    >>> ticker = Ticker()
+    >>> sleep(1)
+    >>> elapsed = ticker.tick()
+    >>> round(elapsed)  #rounded because time.sleep() is not that precise
+    1.0
+    """
     def __init__(self):
         self.__active = False
         self.__last_call = time()
@@ -108,3 +161,9 @@ class Chronometer(object):
         elapsed = now - self.__last_call
         self.__last_call = now
         return elapsed
+
+
+if __name__ == '__main__':
+    import doctest
+
+    doctest.testmod()

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -20,10 +20,46 @@ def to_be_foreground(func):
 
 
 def clamp(value, _min, _max):
+    """
+    Returns a value clamped between two bounds (inclusive)
+    >>> clamp(17, 0, 100)
+    17
+    >>> clamp(-89, 0, 100)
+    0
+    >>> clamp(65635, 0, 100)
+    100
+    """
     return max(_min, min(value, _max))
 
 
+def modulo_list_index(value, _list):
+    """
+    Returns an always valid list index. Repeats the list circularly.
+    >>> robots=['R2D2', 'C3PO', 'HAL9000']
+    >>> robots[modulo_list_index(0, robots)]
+    'R2D2'
+    >>> robots[modulo_list_index(3, robots)]
+    'R2D2'
+    >>> [robots[modulo_list_index(i, robots)] for i in range(10)]
+    ['R2D2', 'C3PO', 'HAL9000', 'R2D2', 'C3PO', 'HAL9000', 'R2D2', 'C3PO', 'HAL9000', 'R2D2']
+    """
+    return value % len(_list)
+
+
 def clamp_list_index(value, _list):
+    """
+    Returns a list index clamped to the bounds of the list.
+    Useful to prevent iterating out of bounds, repeats the bounds values.
+    >>> astronauts = ['Collins', 'Armstrong', 'Aldrin']
+    >>> astronauts[clamp_list_index(0, astronauts)]
+    'Collins'
+    >>> astronauts[clamp_list_index(2, astronauts)]
+    'Aldrin'
+    >>> astronauts[clamp_list_index(9000, astronauts)]
+    'Aldrin'
+    >>> astronauts[clamp_list_index(-666, astronauts)]
+    'Collins'
+    """
     return clamp(value, 0, len(_list) - 1)
 
 
@@ -161,9 +197,3 @@ class Ticker(object):
         elapsed = now - self.__last_call
         self.__last_call = now
         return elapsed
-
-
-if __name__ == '__main__':
-    import doctest
-
-    doctest.testmod()

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -1,5 +1,6 @@
 import logging
 from functools import wraps
+from time import time
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -49,3 +50,61 @@ def check_value_lock(func):
         return result
 
     return wrapper
+
+
+class Counter(object):
+    def __init__(self):
+        self.__active = False
+        self.__cron = Chronometer()
+        self.__elapsed = 0
+
+    @property
+    def active(self):
+        return self.__active
+
+    @property
+    def elapsed(self):
+        return self.__elapsed
+
+    def update(self):
+        if not self.__active:
+            return
+        self.__elapsed += self.__cron.tick()
+
+    def stop(self):
+        self.__cron.tick()
+        self.__elapsed = 0
+        self.__active = False
+
+    def pause(self):
+        self.__active = False
+
+    def resume(self):
+        self.__cron.tick()
+        self.__active = True
+
+    def start(self):
+        self.stop()
+        self.resume()
+
+    def toggle(self):
+        self.pause() if self.active else self.resume()
+
+    def restart(self):
+        self.start()
+
+
+class Chronometer(object):
+    def __init__(self):
+        self.__active = False
+        self.__last_call = time()
+
+    def tick(self):
+        """
+        :rtype: int
+        :return: the time elapsed since the previous tick
+        """
+        now = time()
+        elapsed = now - self.__last_call
+        self.__last_call = now
+        return elapsed


### PR DESCRIPTION
**Purpose**
Provide more classes to indicate loading times or waiting times to the end users.
Two classes have been added, and a bit of refactoring done.
The PR may be extended to include a more classic (horizontal) loading bar if needed (just ask!)

**Changes**
- Updates the loading bar example app
- renames classes for more consistency 
    - Idle* classes are for screen showing no progress
    - Progress* classes are for showing direct progress (through a bar, or a percentage)
- Adds IdleCircular class (a.k.a. throbber)
- Adds ProgressCircular class (a.k.a. looping loading bar)
- moves Chronometer to ui.utils
- moves Counter to ui.utils