### PR TITLE
Logging unification

### DIFF
--- a/apps/app_manager.py
+++ b/apps/app_manager.py
@@ -1,13 +1,12 @@
 import importlib
-import logging
 import os
 import traceback
 
 from apps import zero_app
 from ui import Printer, Menu
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+from helpers import setup_logger
+logger = setup_logger(__name__, "info")
 
 
 class ListWithMetadata(list):

--- a/apps/example_apps/char_arrow_input/main.py
+++ b/apps/example_apps/char_arrow_input/main.py
@@ -1,6 +1,11 @@
-menu_name = "Char input app" 
+import logging
+
+from helpers.logger import setup_logger
+
+menu_name = "Char input app"
 
 from ui import CharArrowKeysInput as Input
+logger = setup_logger(__name__, logging.INFO)
 
 #Some globals for us
 i = None #Input device
@@ -9,7 +14,7 @@ o = None #Output device
 #Callback for ZPUI. It gets called when application is activated in the main menu
 def callback():
     char_input = Input(i, o, initial_value = "password")
-    print(repr(char_input.activate()))
+    logger.info(repr(char_input.activate()))
 
 def init_app(input, output):
     global i, o

--- a/apps/example_apps/char_arrow_input/main.py
+++ b/apps/example_apps/char_arrow_input/main.py
@@ -1,11 +1,11 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Char input app"
 
 from ui import CharArrowKeysInput as Input
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 #Some globals for us
 i = None #Input device

--- a/apps/example_apps/class_based_skeleton/main.py
+++ b/apps/example_apps/class_based_skeleton/main.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-import logging
+
 from subprocess import call
 from apps.zero_app import ZeroApp
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui import Menu, Printer
 
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 
 class SkeletonApp(ZeroApp):

--- a/apps/example_apps/class_based_skeleton/main.py
+++ b/apps/example_apps/class_based_skeleton/main.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
-
+import logging
 from subprocess import call
 from apps.zero_app import ZeroApp
+from helpers.logger import setup_logger
 from ui import Menu, Printer
+
+
+logger = setup_logger(__name__, logging.INFO)
 
 
 class SkeletonApp(ZeroApp):
@@ -22,7 +26,7 @@ class SkeletonApp(ZeroApp):
 
     def call_internal(self):
         Printer(["Calling internal", "command"], self.i, self.o, 1)
-        print("Success")
+        logger.info("Success")
 
     def call_external(self):
         Printer(["Calling external", "command"], self.i, self.o, 1)

--- a/apps/example_apps/dialog_test/main.py
+++ b/apps/example_apps/dialog_test/main.py
@@ -1,12 +1,12 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "DialogBox test" #App name as seen in main menu while using the system
 
 from ui import DialogBox
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 #Some globals for us
 i = None #Input device
 o = None #Output device

--- a/apps/example_apps/dialog_test/main.py
+++ b/apps/example_apps/dialog_test/main.py
@@ -1,15 +1,20 @@
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "DialogBox test" #App name as seen in main menu while using the system
 
 from ui import DialogBox
 
+logger = setup_logger(__name__, logging.INFO)
 #Some globals for us
 i = None #Input device
 o = None #Output device
 
 def callback():
-    print(DialogBox('ync', i, o, message="It's working?").activate())
-    print(DialogBox('yyy', i, o, message="Isn't it beautiful?").activate())
-    print(DialogBox([["Yes", True], ["Absolutely", True]], i, o, message="Do you like it").activate())
+    logger.info(DialogBox('ync', i, o, message="It's working?").activate())
+    logger.info((DialogBox('yyy', i, o, message="Isn't it beautiful?").activate()))
+    logger.info((DialogBox([["Yes", True], ["Absolutely", True]], i, o, message="Do you like it").activate()))
 
 def init_app(input, output):
     global i, o

--- a/apps/example_apps/listbox_test/main.py
+++ b/apps/example_apps/listbox_test/main.py
@@ -1,7 +1,12 @@
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "Listbox test" #App name as seen in main menu while using the system
 
 from ui import Listbox
 
+logger = setup_logger(__name__, logging.INFO)
 #Some globals for us
 i = None #Input device
 o = None #Output device
@@ -11,7 +16,7 @@ def callback():
     ["Number", 101],
     ["String", "stringstring"],
     ["Tuple", (1, 2, 3)]]
-    print(Listbox(listbox_contents, i, o).activate())
+    logger.info(Listbox(listbox_contents, i, o).activate())
 
 def init_app(input, output):
     global i, o

--- a/apps/example_apps/listbox_test/main.py
+++ b/apps/example_apps/listbox_test/main.py
@@ -1,12 +1,12 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Listbox test" #App name as seen in main menu while using the system
 
 from ui import Listbox
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 #Some globals for us
 i = None #Input device
 o = None #Output device

--- a/apps/example_apps/number_input/main.py
+++ b/apps/example_apps/number_input/main.py
@@ -1,6 +1,6 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Number input app"
 
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from ui import IntegerInDecrementInput as Input
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 i = None #Input device
 o = None #Output device

--- a/apps/example_apps/number_input/main.py
+++ b/apps/example_apps/number_input/main.py
@@ -1,8 +1,14 @@
-menu_name = "Number input app" 
+import logging
+
+from helpers.logger import setup_logger
+
+menu_name = "Number input app"
 
 from datetime import datetime
 
 from ui import IntegerInDecrementInput as Input
+
+logger = setup_logger(__name__, logging.INFO)
 
 i = None #Input device
 o = None #Output device
@@ -10,7 +16,7 @@ o = None #Output device
 #Callback for ZPUI. It gets called when application is activated in the main menu
 def callback():
     number_input = Input(0, i, o)
-    print(number_input.activate())
+    logger.info(number_input.activate())
 
 def init_app(input, output):
     global i, o

--- a/apps/example_apps/numbered_input_menu_test/main.py
+++ b/apps/example_apps/numbered_input_menu_test/main.py
@@ -1,9 +1,12 @@
 # coding=utf-8
+import logging
 
 from apps.zero_app import ZeroApp
+from helpers.logger import setup_logger
 from ui import NumberedMenu
 import random
 
+logger = setup_logger(__name__, logging.INFO)
 class NumberedInputTestApp(ZeroApp):
 
     def __init__(self, i, o):
@@ -17,7 +20,7 @@ class NumberedInputTestApp(ZeroApp):
 
     @staticmethod
     def print_hello(index, hello):
-        print("{} {}".format(index, hello))
+        logger.info("{} {}".format(index, hello))
 
     def on_start(self):
         super(NumberedInputTestApp, self).on_start()

--- a/apps/example_apps/numbered_input_menu_test/main.py
+++ b/apps/example_apps/numbered_input_menu_test/main.py
@@ -1,12 +1,12 @@
 # coding=utf-8
-import logging
+
 
 from apps.zero_app import ZeroApp
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui import NumberedMenu
 import random
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 class NumberedInputTestApp(ZeroApp):
 
     def __init__(self, i, o):

--- a/apps/example_apps/numpad_input/main.py
+++ b/apps/example_apps/numpad_input/main.py
@@ -1,7 +1,12 @@
-menu_name = "Char input app" 
+import logging
+
+from helpers.logger import setup_logger
+
+menu_name = "Char input app"
 
 from ui import NumpadCharInput as CharInput, NumpadNumberInput as NumberInput
 
+logger = setup_logger(__name__, logging.INFO)
 #Some globals for us
 i = None #Input device
 o = None #Output device
@@ -9,9 +14,9 @@ o = None #Output device
 #Callback for ZPUI. It gets called when application is activated in the main menu
 def callback():
     char_input = CharInput(i, o, message="Input characters")
-    print(repr(char_input.activate()))
+    logger.info(repr(char_input.activate()))
     number_input = NumberInput(i, o, message="Input numbers")
-    print(repr(number_input.activate()))
+    logger.info(repr(number_input.activate()))
 
 def init_app(input, output):
     global i, o

--- a/apps/example_apps/numpad_input/main.py
+++ b/apps/example_apps/numpad_input/main.py
@@ -1,12 +1,12 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Char input app"
 
 from ui import NumpadCharInput as CharInput, NumpadNumberInput as NumberInput
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 #Some globals for us
 i = None #Input device
 o = None #Output device

--- a/apps/example_apps/skeleton/main.py
+++ b/apps/example_apps/skeleton/main.py
@@ -1,3 +1,7 @@
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "Skeleton app"  # App name as seen in main menu while using the system
 
 from subprocess import call
@@ -5,9 +9,11 @@ from time import sleep
 
 from ui import Menu, Printer
 
+logger = setup_logger(__name__, logging.INFO)
+
 def call_internal():
     Printer(["Calling internal", "command"], i, o, 1)
-    print("Success")
+    logger.info("Success")
 
 def call_external():
     Printer(["Calling external", "command"], i, o, 1)

--- a/apps/example_apps/skeleton/main.py
+++ b/apps/example_apps/skeleton/main.py
@@ -1,6 +1,6 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Skeleton app"  # App name as seen in main menu while using the system
 
@@ -9,7 +9,7 @@ from time import sleep
 
 from ui import Menu, Printer
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 def call_internal():
     Printer(["Calling internal", "command"], i, o, 1)

--- a/apps/hardware_apps/i2ctools/main.py
+++ b/apps/hardware_apps/i2ctools/main.py
@@ -1,3 +1,7 @@
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "I2C tools"
 
 from subprocess import call
@@ -7,6 +11,7 @@ from time import sleep
 
 import smbus
 
+logger = setup_logger(__name__, logging.WARNING)
 current_bus = None
 
 def i2c_detect():
@@ -23,7 +28,7 @@ def i2c_detect():
          elif e.errno == 121:
              pass
          else:
-             print("Errno {} unknown - can be used? {}".format(e.errno, repr(e)))
+             logger.error("Errno {} unknown - can be used? {}".format(e.errno, repr(e)))
       else:
          found_devices[device] = "ok"
     if not found_devices:

--- a/apps/hardware_apps/i2ctools/main.py
+++ b/apps/hardware_apps/i2ctools/main.py
@@ -1,6 +1,6 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "I2C tools"
 
@@ -11,7 +11,7 @@ from time import sleep
 
 import smbus
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 current_bus = None
 
 def i2c_detect():

--- a/apps/hardware_apps/usb/main.py
+++ b/apps/hardware_apps/usb/main.py
@@ -1,3 +1,7 @@
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "USB control"
 
 from zerophone_hw import USB_DCDC
@@ -5,6 +9,7 @@ from ui import Menu, Printer
 from time import sleep
 import os
 
+logger = setup_logger(__name__, logging.WARNING)
 i = None
 o = None
 
@@ -51,14 +56,14 @@ def init_app(input, output):
     device_files = os.listdir(usb_file_base_dir)
     usb_files = [file for file in device_files if file.endswith(".usb")]
     if not usb_files:
-        print("Can't find suitable USB file at {}! What's wrong with this hardware?".format(usb_file_base_dir))
+        logger.error("Can't find suitable USB file at {}! What's wrong with this hardware?".format(usb_file_base_dir))
         raise IOError
     usb_file = usb_files[0] #I'm guessing having more than one file would mean 
     #having more than one USB controller, so this is not Raspberry Pi stuff anymore
     #and I can only test this on a Pi right now.
     usb_full_path = os.path.join(usb_file_base_dir, usb_file, usb_control_file)
     if not os.path.exists(usb_full_path):
-        print("Can't find {} file at {}! What's wrong with this hardware?".format(usb_control_file, usb_full_path))
+        logger.error("Can't find {} file at {}! What's wrong with this hardware?".format(usb_control_file, usb_full_path))
         raise IOError
         
 def callback():

--- a/apps/hardware_apps/usb/main.py
+++ b/apps/hardware_apps/usb/main.py
@@ -1,6 +1,6 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "USB control"
 
@@ -9,7 +9,7 @@ from ui import Menu, Printer
 from time import sleep
 import os
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 i = None
 o = None
 

--- a/apps/network_apps/upnp/main.py
+++ b/apps/network_apps/upnp/main.py
@@ -1,4 +1,8 @@
 #Code taken from here: https://habrahabr.ru/post/332812/ and, consequently, from here: https://www.electricmonk.nl/log/2016/07/05/exploring-upnp-with-python/
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "UPnP/SSDP scan"
 
 from ui import Menu, Printer, IntegerAdjustInput, format_for_screen as ffs
@@ -10,6 +14,9 @@ from time import sleep
 import socket
 import sys
 import os
+
+
+logger = setup_logger(__name__, logging.WARNING)
 
 #Some globals for us
 i = None
@@ -41,8 +48,9 @@ def run_scan():
             data, addr = s.recvfrom(32*1024)
         except socket.timeout:
             break
-        except:
-            print(format_exc())
+        except Exception as e:
+            logger.error(format_exc())
+            logger.exception(e)
         else:
             ip_str = "{}:{}".format(*addr)
             found_devices[ip_str] = data

--- a/apps/network_apps/upnp/main.py
+++ b/apps/network_apps/upnp/main.py
@@ -1,7 +1,7 @@
 #Code taken from here: https://habrahabr.ru/post/332812/ and, consequently, from here: https://www.electricmonk.nl/log/2016/07/05/exploring-upnp-with-python/
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "UPnP/SSDP scan"
 
@@ -16,7 +16,7 @@ import sys
 import os
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 #Some globals for us
 i = None

--- a/apps/network_apps/wpa_cli/main.py
+++ b/apps/network_apps/wpa_cli/main.py
@@ -1,6 +1,6 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Wireless"
 
@@ -15,7 +15,7 @@ from ui import Menu, Printer, MenuExitException, NumpadCharInput, Refresher, Dia
 
 import wpa_cli
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 def show_scan_results():
     network_menu_contents = []
     networks = wpa_cli.get_scan_results()

--- a/apps/network_apps/wpa_cli/main.py
+++ b/apps/network_apps/wpa_cli/main.py
@@ -1,3 +1,7 @@
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "Wireless"
 
 i = None
@@ -11,6 +15,7 @@ from ui import Menu, Printer, MenuExitException, NumpadCharInput, Refresher, Dia
 
 import wpa_cli
 
+logger = setup_logger(__name__, logging.WARNING)
 def show_scan_results():
     network_menu_contents = []
     networks = wpa_cli.get_scan_results()
@@ -83,11 +88,12 @@ def etdn_runner():
     saved_networks = wpa_cli.list_configured_networks()
     for network in saved_networks:
         if network["flags"] == "[TEMP-DISABLED]":
-            print("Network {} is temporarily disabled, re-enabling".format(network["ssid"]))
+            logger.warning("Network {} is temporarily disabled, re-enabling".format(network["ssid"]))
             try:
                 enable_network(network["network_id"])
-            except:
-                print(format_exc())
+            except Exception as e:
+                logger.error(format_exc())
+                logger.exception(e)
     etdn_thread = None
 
 def scan(delay = True):

--- a/apps/network_apps/wpa_cli/wpa_cli.py
+++ b/apps/network_apps/wpa_cli/wpa_cli.py
@@ -1,10 +1,10 @@
-import logging
+
 from subprocess import check_output, CalledProcessError
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 #wpa_cli related functions and objects
 def wpa_cli_command(*command):

--- a/apps/network_apps/wpa_cli/wpa_cli.py
+++ b/apps/network_apps/wpa_cli/wpa_cli.py
@@ -1,5 +1,10 @@
+import logging
 from subprocess import check_output, CalledProcessError
 from time import sleep
+
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.WARNING)
 
 #wpa_cli related functions and objects
 def wpa_cli_command(*command):
@@ -35,13 +40,13 @@ def connect_new_network(network_info):
     #Then, if it's an open network, just connecting
     if is_open_network(network_info):
         network_id = add_network()
-        print(set_network(network_id, 'ssid', '"'+network_info['ssid']+'"'))
+        logger.info(set_network(network_id, 'ssid', '"'+network_info['ssid']+'"'))
         set_network(network_id, 'key_mgmt', 'NONE')
         select_network(network_id)
         return True
     #Else, there's not enough implemented as for now
     if not network_found:
-        print("Hell, I dunno.")
+        logger.warning("Hell, I dunno.")
         return False  
 
 def is_open_network(network_info):

--- a/apps/personal/contacts/address_book.py
+++ b/apps/personal/contacts/address_book.py
@@ -1,9 +1,9 @@
-import logging
 import os
 import pickle
 
 from helpers import Singleton, flatten
-
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 class AddressBook(Singleton):
     def __init__(self):
@@ -60,7 +60,7 @@ class AddressBook(Singleton):
     def load_from_file(self):
         save_path = self.get_save_file_path()
         if not os.path.exists(save_path):
-            logging.error("Could not load. File {} not found".format(save_path))
+            logger.error("Could not load. File {} not found".format(save_path))
             return
         with open(self.get_save_file_path(), 'r') as f_save:
             self._contacts = pickle.load(f_save)

--- a/apps/personal/contacts/main.py
+++ b/apps/personal/contacts/main.py
@@ -1,16 +1,16 @@
 # coding=utf-8
 import argparse
 import doctest
-import logging
+
 import os
 
 from address_book import AddressBook, ZPUI_HOME, Contact
 from apps import ZeroApp
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui import NumberedMenu, Listbox
 from vcard_converter import VCardContactConverter
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 
 class ContactApp(ZeroApp):

--- a/apps/personal/contacts/main.py
+++ b/apps/personal/contacts/main.py
@@ -1,13 +1,17 @@
 # coding=utf-8
 import argparse
 import doctest
+import logging
 import os
 
-from apps import ZeroApp
-from ui import NumberedMenu, Listbox
-
 from address_book import AddressBook, ZPUI_HOME, Contact
+from apps import ZeroApp
+from helpers.logger import setup_logger
+from ui import NumberedMenu, Listbox
 from vcard_converter import VCardContactConverter
+
+logger = setup_logger(__name__, logging.INFO)
+
 
 class ContactApp(ZeroApp):
     def __init__(self, i, o):
@@ -49,7 +53,7 @@ def load_vcf(folder):
     for contact in contacts:
         address_book.add_contact(contact)
     address_book.save_to_file()
-    print("Saved to {}".format(address_book.get_save_file_path()))
+    logger.info("Saved to {}".format(address_book.get_save_file_path()))
 
 
 if __name__ == '__main__':
@@ -60,7 +64,7 @@ if __name__ == '__main__':
     arguments = parser.parse_args()
 
     if arguments.test:
-        print("Running tests...")
+        logger.info("Running tests...")
         doctest.testmod()
 
     load_vcf(arguments.src_folder)

--- a/apps/personal/contacts/vcard_converter.py
+++ b/apps/personal/contacts/vcard_converter.py
@@ -1,4 +1,5 @@
-import logging
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 from helpers import install_from_pip
 
@@ -39,7 +40,7 @@ class VCardContactConverter(object):
         # type: (str) -> list
         file_content = VCardContactConverter.read_file_content(file_path)
         contacts = [c for c in vobject.readComponents(file_content, ignoreUnreadable=True)]
-        logging.info("Found {} contact in file {}", len(contacts), file_path)
+        logger.info("Found {} contact in file {}", len(contacts), file_path)
         return contacts
 
     @staticmethod
@@ -54,5 +55,5 @@ class VCardContactConverter(object):
         contacts = []
         for file_path in contact_card_files:
             contacts += VCardContactConverter.parse_vcard_file(file_path)
-        logging.info("finished : {} contacts loaded", len(contacts))
+        logger.info("finished : {} contacts loaded", len(contacts))
         return [VCardContactConverter.to_zpui_contact(c) for c in contacts]

--- a/apps/personal/todo_txt/tasklib.py
+++ b/apps/personal/todo_txt/tasklib.py
@@ -1,8 +1,11 @@
+import logging
 from datetime import datetime, date
 import re
 
 #from qtodotxt.lib.task_htmlizer import TaskHtmlizer
+from helpers.logger import setup_logger
 
+logger = setup_logger(__name__, logging.WARNING)
 
 class Task(object):
     """
@@ -80,12 +83,12 @@ class Task(object):
                 if word.startswith('due:'):
                     self.due = self._parseDate(word[4:])
                     if not self.due:
-                        print("Error parsing due date '{}'".format(word))
+                        logger.error("Error parsing due date '{}'".format(word))
                         self.due_error = word[4:]
                 elif word.startswith('t:'):
                     self.threshold = self._parseDate(word[2:])
                     if not self.threshold:
-                        print("Error parsing threshold '{}'".format(word))
+                        logger.error("Error parsing threshold '{}'".format(word))
                         self.threshold_error = word[2:]
                     else:
                         if self.threshold > date.today():

--- a/apps/personal/todo_txt/tasklib.py
+++ b/apps/personal/todo_txt/tasklib.py
@@ -1,11 +1,11 @@
-import logging
+
 from datetime import datetime, date
 import re
 
 #from qtodotxt.lib.task_htmlizer import TaskHtmlizer
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 class Task(object):
     """

--- a/apps/phone/main.py
+++ b/apps/phone/main.py
@@ -1,6 +1,6 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Phone"
 
@@ -15,7 +15,7 @@ from helpers import BackgroundRunner, ExitHelper
 from phone import Phone, Modem, ATError
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 i = None
 o = None

--- a/apps/phone/main.py
+++ b/apps/phone/main.py
@@ -1,4 +1,8 @@
-menu_name = "Phone" 
+import logging
+
+from helpers.logger import setup_logger
+
+menu_name = "Phone"
 
 from subprocess import call as os_call
 from time import sleep
@@ -9,6 +13,9 @@ from ui.experimental import NumberKeypadInputLayer
 from helpers import BackgroundRunner, ExitHelper
 
 from phone import Phone, Modem, ATError
+
+
+logger = setup_logger(__name__, logging.WARNING)
 
 i = None
 o = None
@@ -48,7 +55,7 @@ def call(number):
         phone.call(number)
     except ATError as e:
         Printer(ffs("Calling fail! "+repr(e), o.cols), i, o, 0)
-    print("Function stopped executing")
+    logger.error("Function stopped executing")
  
 def call_view():
     keymap = {"KEY_ANSWER":[call, "value"]}
@@ -96,7 +103,7 @@ def init_app(input, output):
         #This not good enough - either make the systemctl library system-wide or add more checks
         os_call(["systemctl", "stop", "serial-getty@ttyAMA0.service"])
     except Exception as e:
-        print(repr(e))
+        logger.exception(e)
         #import pdb;pdb.set_trace()
     init = BackgroundRunner(init_hardware)
     init.run()

--- a/apps/phone/phone.py
+++ b/apps/phone/phone.py
@@ -4,15 +4,15 @@ from datetime import datetime
 from serial import Serial
 from time import sleep
 from copy import copy
-import logging
+
 import string
 import shlex
 
 import smspdu
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 #Personal data protection technique:
 #All the logging statements&prints that can contain private data

--- a/apps/privacy_apps/tor/tor.py
+++ b/apps/privacy_apps/tor/tor.py
@@ -16,7 +16,7 @@ as well as to discuss application UX."""
 #https://github.com/jamesacampbell/python-examples/
 #http://stackoverflow.com/questions/18561778/how-do-i-get-the-ip-address-of-the-tor-entry-node-in-use
 #... some other places - lost links =(
-import logging
+
 
 from stem.control import Controller
 from stem import Signal, CircStatus
@@ -24,9 +24,9 @@ import requests
 import socks
 import socket
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 socks.set_default_proxy(socks.SOCKS5, "127.0.0.1", 9050)
 

--- a/apps/privacy_apps/tor/tor.py
+++ b/apps/privacy_apps/tor/tor.py
@@ -16,12 +16,17 @@ as well as to discuss application UX."""
 #https://github.com/jamesacampbell/python-examples/
 #http://stackoverflow.com/questions/18561778/how-do-i-get-the-ip-address-of-the-tor-entry-node-in-use
 #... some other places - lost links =(
+import logging
 
 from stem.control import Controller
 from stem import Signal, CircStatus
 import requests
 import socks
 import socket
+
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.INFO)
 
 socks.set_default_proxy(socks.SOCKS5, "127.0.0.1", 9050)
 
@@ -102,11 +107,11 @@ def tor_is_available():
 
 def main():
     info = get_traffic_info
-    print("My Tor relay has read %s bytes and written %s." % info )
-    print(get_external_ip())
-    print(get_entry_ips())
+    logger.info("My Tor relay has read %s bytes and written %s." % info )
+    logger.info(get_external_ip())
+    logger.info(get_entry_ips())
     ddg = get_duckduckgo()	
-    print(ddg.content[:100])
+    logger.debug(ddg.content[:100])
 
     #desc = controller.get_hidden_service_descriptor('3g2upl4pq6kufc4m') #not supported in Raspbian Tor
   

--- a/apps/raspberrypi/tvservice/tvservice.py
+++ b/apps/raspberrypi/tvservice/tvservice.py
@@ -1,8 +1,8 @@
 import json
 from subprocess import check_output, CalledProcessError
 from time import sleep
-from helpers.logger import setup_logger
-logger = setup_logger(__name__, logging.INFO)
+from helpers import setup_logger
+logger = setup_logger(__name__, "info")
 """
 #Not yet implemented:
   -t, --ntsc                        Use NTSC frequency for HDMI mode (e.g. 59.94Hz rather than 60Hz)
@@ -67,7 +67,7 @@ def status():
        result["tv_mode"] = mode
        result["ratio"] = ratio
     else:
-       logger.warning("TVSERVICE APP WARNING: Unexpected tvservice -s output {}".format(output))
+       logger.warning("Unexpected tvservice -s output: {}".format(output))
        result["mode"] = "UNKNOWN"
     return result
 

--- a/apps/raspberrypi/tvservice/tvservice.py
+++ b/apps/raspberrypi/tvservice/tvservice.py
@@ -1,7 +1,7 @@
 import json
 from subprocess import check_output, CalledProcessError
 from time import sleep
-
+logger = setup_logger(__name__, logging.INFO)
 """
 #Not yet implemented:
   -t, --ntsc                        Use NTSC frequency for HDMI mode (e.g. 59.94Hz rather than 60Hz)
@@ -66,7 +66,7 @@ def status():
        result["tv_mode"] = mode
        result["ratio"] = ratio
     else:
-       print("TVSERVICE APP WARNING: Unexpected tvservice -s output {}".format(output))
+       logger.warning("TVSERVICE APP WARNING: Unexpected tvservice -s output {}".format(output))
        result["mode"] = "UNKNOWN"
     return result
 

--- a/apps/raspberrypi/tvservice/tvservice.py
+++ b/apps/raspberrypi/tvservice/tvservice.py
@@ -1,6 +1,7 @@
 import json
 from subprocess import check_output, CalledProcessError
 from time import sleep
+from helpers.logger import setup_logger
 logger = setup_logger(__name__, logging.INFO)
 """
 #Not yet implemented:

--- a/apps/system_apps/systemctl/systemctl.py
+++ b/apps/system_apps/systemctl/systemctl.py
@@ -1,5 +1,9 @@
+import logging
 import subprocess
 
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.WARNING)
 
 def list_units():
     units = []
@@ -17,7 +21,7 @@ def list_units():
             name = name.replace('\\x2d', '-') #Replacing unicode dashes with normal ones
             units.append({"name":name, "load":loaded, "active":active, "sub":details, "description":description, "type":type, "basename":basename})
         else:
-            print("Systemctl: couldn't parse line: {}".format(repr(line)))
+            logger.error("Systemctl: couldn't parse line: {}".format(repr(line)))
     return units         
                      
 def action_unit(action, unit):

--- a/apps/system_apps/systemctl/systemctl.py
+++ b/apps/system_apps/systemctl/systemctl.py
@@ -1,9 +1,9 @@
-import logging
+
 import subprocess
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 def list_units():
     units = []

--- a/apps/test_hardware/main.py
+++ b/apps/test_hardware/main.py
@@ -1,6 +1,6 @@
-import logging
 
-from helpers.logger import setup_logger
+
+from helpers import setup_logger
 
 menu_name = "Hardware test"
 
@@ -14,7 +14,7 @@ import os
 from ui import Menu, Printer, PrettyPrinter, GraphicsPrinter
 from helpers import ExitHelper, local_path_gen
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 i = None
 o = None

--- a/apps/test_hardware/main.py
+++ b/apps/test_hardware/main.py
@@ -1,3 +1,7 @@
+import logging
+
+from helpers.logger import setup_logger
+
 menu_name = "Hardware test"
 
 from threading import Event, Thread
@@ -9,6 +13,8 @@ import os
 
 from ui import Menu, Printer, PrettyPrinter, GraphicsPrinter
 from helpers import ExitHelper, local_path_gen
+
+logger = setup_logger(__name__, logging.WARNING)
 
 i = None
 o = None
@@ -27,7 +33,7 @@ def init_app(input, output):
     if music_filename not in os.listdir(local_path('.')):
         def download():
             downloaded.clear()
-            print("Downloading music for hardware test app!")
+            logger.debug("Downloading music for hardware test app!")
             call(["wget", url, "-O", music_path])
             downloaded.set()
         t = Thread(target=download)

--- a/emulator.py
+++ b/emulator.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python2
 
-import logging
 from multiprocessing import Process, Pipe
 from time import sleep
 
@@ -9,6 +8,8 @@ import luma.emulator.device
 import pygame
 from luma.core.render import canvas
 
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 __EMULATOR_PROXY = None
 
@@ -86,9 +87,9 @@ class Emulator(object):
         try:
             self._event_loop()
         except KeyboardInterrupt:
-            logging.info('Caught KeyboardIterrupt')
+            logger.info('Caught KeyboardIterrupt')
         except:
-            logging.exception('Unknown exception during event loop')
+            logger.exception('Unknown exception during event loop')
             raise
         finally:
             self.child_conn.close()
@@ -135,23 +136,23 @@ class Emulator(object):
             )
 
             if self.cursor_enabled:
-                logging.debug('Drawing cursor with dims: %s', dims)
+                logger.debug('Drawing cursor with dims: %s', dims)
                 draw.rectangle(dims, outline='white')
 
             args = args[:self.rows]
-            logging.debug("type(args)=%s", type(args))
+            logger.debug("type(args)=%s", type(args))
 
             for line, arg in enumerate(args):
-                logging.debug('line %s: arg=%s, type=%s', line, arg, type(arg))
+                logger.debug('line %s: arg=%s, type=%s', line, arg, type(arg))
                 # Emulator only:
                 # Passing anything except a string to draw.text will cause
                 # PIL to throw an exception.  Warn 'em here via the log.
                 if not isinstance(arg, basestring):
-                    logging.warning('emulator only likes strings fed to '
+                    logger.warning('emulator only likes strings fed to '
                         'draw.text, prepare for exception')
                 y = (line * self.char_height - 1) if line != 0 else 0
                 draw.text((2, y), arg, fill='white')
-                logging.debug('after draw.text(2, %d), %s', y, arg)
+                logger.debug('after draw.text(2, %d), %s', y, arg)
 
     def display_image(self, image):
         self.device.display(image)

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -3,3 +3,4 @@ from runners import BooleanEvent, Oneshot, BackgroundRunner
 from config_parse import read_config, write_config, read_or_create_config
 from general import local_path_gen, flatten, Singleton
 from git_update import install_from_pip
+from logger import setup_logger

--- a/helpers/config_parse.py
+++ b/helpers/config_parse.py
@@ -4,10 +4,10 @@ from __future__ import print_function
 import json
 import os
 import shutil
-import logging
+
 
 from helpers.logger import setup_logger
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 def read_config(config_path):
     with open(config_path, 'r') as f:

--- a/helpers/config_parse.py
+++ b/helpers/config_parse.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python2
 import json
+import logging
 
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.WARNING)
 
 def read_config(config_path):
     with open(config_path, 'r') as f:
@@ -17,7 +21,7 @@ def read_or_create_config(config_path, default_config, app_name):
     try:
         config_dict = read_config(config_path)
     except (ValueError, IOError):
-        print("{}: broken/nonexistent config, restoring with defaults...".format(app_name))
+        logger.error("{}: broken/nonexistent config, restoring with defaults...".format(app_name))
         with open(config_path, 'w') as f:
             f.write(default_config)
         config_dict = read_config(config_path)

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,0 +1,9 @@
+import logging
+
+
+def setup_logger(logger_name, logger_level=logging.WARNING):
+    # type: (str, int) -> logging.Logger
+    # todo : read level from config here
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logger_level)
+    return logger

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,9 +1,9 @@
 import logging
 
-
-def setup_logger(logger_name, logger_level=logging.WARNING):
-    # type: (str, int) -> logging.Logger
+def setup_logger(logger_name, log_level="warning"):
+    # type: (str, str) -> logging.Logger
     # todo : read level from config here
+    logger_level_attr = getattr(logging, log_level.upper())
     logger = logging.getLogger(logger_name)
-    logger.setLevel(logger_level)
+    logger.setLevel(logger_level_attr)
     return logger

--- a/input/drivers/custom_i2c.py
+++ b/input/drivers/custom_i2c.py
@@ -1,7 +1,11 @@
+import logging
+
 import smbus
 from time import sleep
 
+from helpers.logger import setup_logger
 from skeleton import InputSkeleton
+logger = setup_logger(__name__, logging.WARNING)
 
 class InputDevice(InputSkeleton):
     default_mapping = [
@@ -81,12 +85,12 @@ class InputDevice(InputSkeleton):
                 try:
                     data = self.bus.read_byte(self.addr)
                 except IOError:
-                    print("Can't get data from keypad!")
+                    logger.error("Can't get data from keypad!")
                 else:
                     if data != 0:
                         self.send_key(self.mapping[data-1])
                     else:
-                        print("Received 0 from keypad though the interrupt has been triggered!")
+                        logger.warning("Received 0 from keypad though the interrupt has been triggered!")
                         sleep(0.1)
             sleep(0.1)
 

--- a/input/drivers/custom_i2c.py
+++ b/input/drivers/custom_i2c.py
@@ -1,11 +1,11 @@
-import logging
+
 
 import smbus
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from skeleton import InputSkeleton
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 class InputDevice(InputSkeleton):
     default_mapping = [

--- a/input/drivers/hid.py
+++ b/input/drivers/hid.py
@@ -1,12 +1,12 @@
-import logging
+
 
 from evdev import InputDevice as HID, list_devices, ecodes
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from skeleton import InputSkeleton
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 def get_input_devices():
     """Returns list of all the available InputDevices"""
     devices = []

--- a/input/drivers/hid.py
+++ b/input/drivers/hid.py
@@ -1,8 +1,12 @@
+import logging
+
 from evdev import InputDevice as HID, list_devices, ecodes
 from time import sleep
 
+from helpers.logger import setup_logger
 from skeleton import InputSkeleton
 
+logger = setup_logger(__name__, logging.WARNING)
 def get_input_devices():
     """Returns list of all the available InputDevices"""
     devices = []
@@ -59,7 +63,7 @@ class InputDevice(InputSkeleton):
         try:
             self.device = HID(self.path)
         except OSError:
-            print("Failed HID")
+            logger.error("Failed HID")
             return False
         else:
             self.device.grab() #Can throw exception if already grabbed

--- a/input/drivers/pfcad.py
+++ b/input/drivers/pfcad.py
@@ -1,7 +1,12 @@
+import logging
 import threading
 import pifacecad
 
 from time import sleep
+
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.WARNING)
 
 class InputDevice():
     """ A driver for PiFace Control and Display Raspberry Pi shields. It has 5 buttons, one single-axis joystick with a pushbutton, a 16x2 HD44780 screen and an IR receiver (not used yet)."""
@@ -49,7 +54,7 @@ class InputDevice():
 
     def send_key(self, keycode):
         """A hook to be overridden by ``InputListener``. Otherwise, prints out key names as soon as they're pressed so is useful for debugging."""
-        print(keycode)
+        logger.info(keycode)
 
     def stop(self):
         """Sets the ``stop_flag`` for loop function."""

--- a/input/drivers/pfcad.py
+++ b/input/drivers/pfcad.py
@@ -1,12 +1,12 @@
-import logging
+
 import threading
 import pifacecad
 
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 class InputDevice():
     """ A driver for PiFace Control and Display Raspberry Pi shields. It has 5 buttons, one single-axis joystick with a pushbutton, a 16x2 HD44780 screen and an IR receiver (not used yet)."""

--- a/input/drivers/pygame_input.py
+++ b/input/drivers/pygame_input.py
@@ -1,14 +1,14 @@
-import logging
+
 from time import sleep
 
 import pygame
 
 import emulator
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from skeleton import InputSkeleton
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 USED_KEYS = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
     'UP', 'DOWN', 'LEFT', 'RIGHT', 'RETURN', 'PAGEUP', 'PAGEDOWN'

--- a/input/drivers/pygame_input.py
+++ b/input/drivers/pygame_input.py
@@ -4,9 +4,11 @@ from time import sleep
 import pygame
 
 import emulator
+from helpers.logger import setup_logger
 from skeleton import InputSkeleton
 
 
+logger = setup_logger(__name__, logging.WARNING)
 USED_KEYS = [
     '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
     'UP', 'DOWN', 'LEFT', 'RIGHT', 'RETURN', 'PAGEUP', 'PAGEDOWN'
@@ -35,7 +37,7 @@ class InputDevice(InputSkeleton):
 
         #TODO: debug and fix race condition
         while not hasattr(self, "emulator"):
-            print("Input emulator not yet ready (a bug, TOFIX)")
+            logger.debug("Input emulator not yet ready (a bug, TOFIX)")
             sleep(0.1)
 
         while not self.stop_flag:

--- a/input/drivers/skeleton.py
+++ b/input/drivers/skeleton.py
@@ -1,9 +1,9 @@
-import logging
+
 import threading
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 class InputSkeleton():
     """Base class for input devices. Expectations from children:

--- a/input/drivers/skeleton.py
+++ b/input/drivers/skeleton.py
@@ -1,4 +1,9 @@
+import logging
 import threading
+
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.WARNING)
 
 class InputSkeleton():
     """Base class for input devices. Expectations from children:
@@ -18,8 +23,9 @@ class InputSkeleton():
             self.mapping = self.default_mapping
         try:
             self.init_hw()
-        except AtrributeError:
-            print("init_hw function not found!")
+        except Exception as e:
+            logger.error("init_hw function not found!")
+            logger.exception(e)
         if threaded:
             self.start_thread()
 
@@ -33,7 +39,7 @@ class InputSkeleton():
 
     def send_key(self, key):
         """A hook to be overridden by ``InputListener``. Otherwise, prints out key names as soon as they're pressed so is useful for debugging (to test things, just launch the driver as ``python driver.py``)"""
-        print(key)
+        logger.debug(key)
 
     def start_thread(self):
         """Starts a thread with ``start`` function as target."""

--- a/input/input.py
+++ b/input/input.py
@@ -2,16 +2,16 @@ from traceback import format_exc
 from threading import Thread, Event
 from time import sleep
 import importlib
-import logging
+
 import atexit
 import Queue
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
 import inspect
 
 listener = None
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 class CallbackException(Exception):
     def __init__(self, errno=0, message=""):

--- a/input/input.py
+++ b/input/input.py
@@ -9,7 +9,6 @@ from helpers.logger import setup_logger
 
 import inspect
 
-
 listener = None
 
 logger = setup_logger(__name__, logging.WARNING)
@@ -146,9 +145,10 @@ class InputListener():
         if callable(self.backlight_cb):
             try:
                 backlight_was_off = self.backlight_cb()
-            except:
-                print("Exception while calling the backlight callback!")
-                print(format_exc())
+            except Exception as e:
+                logger.error("Exception while calling the backlight callback!")
+                print(format_exc())# todo : to be removed ?
+                logger.exception(e)
             else:
                 #If backlight was off, ignore the keypress
                 if backlight_was_off is True:

--- a/input/input.py
+++ b/input/input.py
@@ -1,18 +1,18 @@
-from traceback import print_exc, format_exc
+from traceback import format_exc
 from threading import Thread, Event
 from time import sleep
 import importlib
 import logging
 import atexit
 import Queue
-import sys
+from helpers.logger import setup_logger
 
 import inspect
 
+
 listener = None
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
+logger = setup_logger(__name__, logging.WARNING)
 
 class CallbackException(Exception):
     def __init__(self, errno=0, message=""):

--- a/output/drivers/adafruit_plate.py
+++ b/output/drivers/adafruit_plate.py
@@ -1,8 +1,13 @@
+import logging
+
 import smbus
 from time import sleep
 
+from helpers.logger import setup_logger
 from output.output import OutputDevice
 
+
+logger = setup_logger(__name__, logging.WARNING)
 
 def delay(time):
     sleep(time/1000.0)
@@ -53,7 +58,7 @@ class Screen(HD44780, BacklightManager, OutputDevice):
     def write_byte(self, byte, char_mode=False):
         """Takes a byte and sends the high nibble, then the low nibble (as per HD44780 doc). Passes ``char_mode`` to ``self.write4bits``."""
         if self.debug and not char_mode:        
-            print(hex(byte))                    
+            logger.debug(hex(byte))
         self.write4bits(byte >> 4, char_mode)   
         self.write4bits(byte & 0x0F, char_mode) 
 

--- a/output/drivers/adafruit_plate.py
+++ b/output/drivers/adafruit_plate.py
@@ -1,13 +1,13 @@
-import logging
+
 
 import smbus
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from output.output import OutputDevice
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 def delay(time):
     sleep(time/1000.0)

--- a/output/drivers/arduino_lcd.py
+++ b/output/drivers/arduino_lcd.py
@@ -1,13 +1,13 @@
-import logging
+
 
 from serial import Serial
 from time import sleep
 
 #Firmware: TODO
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from output.output import OutputDevice
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 def delay(time):
     sleep(time/1000.0)

--- a/output/drivers/arduino_lcd.py
+++ b/output/drivers/arduino_lcd.py
@@ -1,9 +1,13 @@
+import logging
+
 from serial import Serial
 from time import sleep
 
 #Firmware: TODO
+from helpers.logger import setup_logger
 from output.output import OutputDevice
 
+logger = setup_logger(__name__, logging.WARNING)
 
 def delay(time):
     sleep(time/1000.0)
@@ -36,7 +40,7 @@ class Screen(HD44780, OutputDevice):
     def write_byte(self, byte, char_mode=False):
         """Takes a byte and sends the high nibble, then the low nibble (as per HD44780 doc). Passes ``char_mode`` to ``self.write4bits``."""
         if self.debug and not char_mode:        
-            print(hex(byte))
+            logger.debug(hex(byte))
         if char_mode:                    
             self.serial.write(str(bytearray([0xfe, byte])))
         else:

--- a/output/drivers/mcp23008.py
+++ b/output/drivers/mcp23008.py
@@ -1,12 +1,12 @@
-import logging
+
 
 import smbus
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from output.output import OutputDevice
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 def delay(time):
     sleep(time/1000.0)

--- a/output/drivers/mcp23008.py
+++ b/output/drivers/mcp23008.py
@@ -1,8 +1,12 @@
+import logging
+
 import smbus
 from time import sleep
 
+from helpers.logger import setup_logger
 from output.output import OutputDevice
 
+logger = setup_logger(__name__, logging.WARNING)
 
 def delay(time):
     sleep(time/1000.0)
@@ -43,7 +47,7 @@ class Screen(HD44780, OutputDevice):
     def write_byte(self, byte, char_mode=False):
         """Takes a byte and sends the high nibble, then the low nibble (as per HD44780 doc). Passes ``char_mode`` to ``self.write4bits``."""
         if self.debug and not char_mode:        
-            print(hex(byte))                    
+            logger.debug(hex(byte))
         self.write4bits(byte >> 4, char_mode)   
         self.write4bits(byte & 0x0F, char_mode) 
 

--- a/output/drivers/pcf8574.py
+++ b/output/drivers/pcf8574.py
@@ -1,14 +1,14 @@
-import logging
+
 
 import smbus
 from time import sleep
 
 from hd44780 import HD44780
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from output.output import OutputDevice
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 def delay(time):
     sleep(time/1000.0)

--- a/output/drivers/pcf8574.py
+++ b/output/drivers/pcf8574.py
@@ -1,9 +1,14 @@
+import logging
+
 import smbus
 from time import sleep
 
 from hd44780 import HD44780
+from helpers.logger import setup_logger
 from output.output import OutputDevice
 
+
+logger = setup_logger(__name__, logging.WARNING)
 
 def delay(time):
     sleep(time/1000.0)
@@ -51,7 +56,7 @@ class Screen(HD44780, OutputDevice):
     def write_byte(self, data, char_mode = False):
         """Takes a byte and sends the high nibble, then the low nibble (as per HD44780 doc). Passes ``char_mode`` to ``self.write4bits``."""
         if self.debug and not char_mode:
-            print(hex(data))
+            logger.debug(hex(data))
         self.write4bits((data & 0xF0), char_mode)
         self.write4bits((data << 4), char_mode)
 

--- a/output/drivers/pi_gpio.py
+++ b/output/drivers/pi_gpio.py
@@ -6,14 +6,14 @@
 # LiquidCrystal - https://github.com/arduino/Arduino/blob/master/libraries/LiquidCrystal/LiquidCrystal.cpp
 # Adafruit - https://github.com/adafruit/Adafruit-Raspberry-Pi-Python-Code
 #
-import logging
+
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from output.output import OutputDevice
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 def delayMicroseconds(microseconds):
     seconds = microseconds / float(1000000)  # divide microseconds by 1 million for seconds

--- a/output/drivers/pi_gpio.py
+++ b/output/drivers/pi_gpio.py
@@ -6,11 +6,14 @@
 # LiquidCrystal - https://github.com/arduino/Arduino/blob/master/libraries/LiquidCrystal/LiquidCrystal.cpp
 # Adafruit - https://github.com/adafruit/Adafruit-Raspberry-Pi-Python-Code
 #
-
+import logging
 from time import sleep
 
+from helpers.logger import setup_logger
 from output.output import OutputDevice
 
+
+logger = setup_logger(__name__, logging.WARNING)
 
 def delayMicroseconds(microseconds):
     seconds = microseconds / float(1000000)  # divide microseconds by 1 million for seconds
@@ -18,9 +21,10 @@ def delayMicroseconds(microseconds):
 
 try:
     import RPi.GPIO as GPIO
-except:
-    print("Couldn't mock that one for ReadTheDocs")
-    print("Or maybe it's a user who just doesn't have that installed?")
+except Exception as e:
+    logger.error("Couldn't mock that one for ReadTheDocs")
+    logger.error("Or maybe it's a user who just doesn't have that installed?")
+    logger.exception(e)
 
 from hd44780 import HD44780
 
@@ -56,7 +60,7 @@ class Screen(HD44780, OutputDevice):
     def write_byte(self, byte, char_mode=False):
         """Takes a byte and sends the high nibble, then the low nibble (as per HD44780 doc). Passes ``char_mode`` to ``self.write4bits``."""
         if self.debug and not char_mode:        
-            print(hex(byte))                    
+            logger.debug(hex(byte))
         self.write4bits(byte >> 4, char_mode)   
         self.write4bits(byte & 0x0F, char_mode) 
 

--- a/output/drivers/pygame_emulator.py
+++ b/output/drivers/pygame_emulator.py
@@ -4,7 +4,6 @@ Allows development of sofware without ZeroPhone hardware,
 e.g. on a laptop with a USB keyboard.
 """
 
-import logging
 from threading import Event
 from time import sleep
 
@@ -12,7 +11,8 @@ from luma.core.render import canvas
 
 import emulator
 from output.output import OutputDevice
-
+from helpers import setup_logger
+logger = setup_logger(__name__, "info")
 
 class Screen(OutputDevice):
     """
@@ -42,7 +42,7 @@ class Screen(OutputDevice):
         Creates subprocess of a of pygame emulator device
         """
 
-        logging.debug('Creating emulator instance')
+        logger.debug('Creating emulator instance')
         self.emulator = emulator.get_emulator()
 
     def __getattr__(self, name):

--- a/output/drivers/pygame_emulator_factory.py
+++ b/output/drivers/pygame_emulator_factory.py
@@ -6,12 +6,13 @@ returns it to caller
 """
 import logging
 import luma.emulator.device
+from helpers.logger import setup_logger
 
 # ignore PIL debug messages
+
 logging.getLogger("PIL").setLevel(logging.ERROR)
 
-logger = logging.getLogger(__name__)
-#logger.setLevel(logging.DEBUG)
+logger = setup_logger(__name__)
 
 def get_pygame_emulator_device(width=128, height=64):
     """

--- a/output/drivers/pygame_emulator_factory.py
+++ b/output/drivers/pygame_emulator_factory.py
@@ -4,9 +4,9 @@ sets minimum attributes,
 creates device
 returns it to caller
 """
-import logging
+
 import luma.emulator.device
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
 # ignore PIL debug messages
 

--- a/ui/base_list_ui.py
+++ b/ui/base_list_ui.py
@@ -8,12 +8,12 @@ from time import sleep
 from PIL import ImageFont
 from luma.core.render import canvas as luma_canvas
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from utils import to_be_foreground, clamp_list_index
 
-import logging
 
-logger = setup_logger(__name__, logging.WARNING)
+
+logger = setup_logger(__name__, "warning")
 
 #Documentation building process has problems with this import
 try:

--- a/ui/base_list_ui.py
+++ b/ui/base_list_ui.py
@@ -25,8 +25,9 @@ else:
     cm.set_path("ui/configs")
     try:
         config = cm.get_global_config()
-    except OSError:
-        print("Config files not available, running under ReadTheDocs?")
+    except OSError as e:
+        logger.error("Config files not available, running under ReadTheDocs?")
+        logger.exception(e)
 
 
 class BaseListUIElement():
@@ -77,7 +78,7 @@ class BaseListUIElement():
             view_config = config["custom_views"][self.name]
             if isinstance(view_config, basestring):
                 if view_config not in self.views:
-                    print('Unknown view "{}" given for UI element "{}"!'.format(view_config, self.name))
+                    logger.warning('Unknown view "{}" given for UI element "{}"!'.format(view_config, self.name))
                 else:
                     view = self.views[view_config]
             elif isinstance(view_config, dict):
@@ -85,12 +86,12 @@ class BaseListUIElement():
                 #This is the part where fine-tuning views will be possible, 
                 #once passing args&kwargs is implemented, that is
             else:
-                print("Custom view description can only be a string or a dictionary; is {}!".format(type(view_config)))
+                logger.error("Custom view description can only be a string or a dictionary; is {}!".format(type(view_config)))
         elif not view and "default" in config:
             view_config = config["default"]
             if isinstance(view_config, basestring):
                 if view_config not in self.views:
-                    print('Unknown view "{}" given for UI element "{}"!'.format(view_config, self.name))
+                    logger.warning('Unknown view "{}" given for UI element "{}"!'.format(view_config, self.name))
                 else: 
                     view = self.views[view_config]
             elif isinstance(view_config, dict):
@@ -251,7 +252,7 @@ class BaseListUIElement():
     def select_entry(self):
         """To be overridden by child UI elements. Is executed when ENTER is pressed
            in UI element."""
-        print(self.contents[self.pointer])
+        logger.debug(self.contents[self.pointer])
 
     #Working with the keymap
 

--- a/ui/base_list_ui.py
+++ b/ui/base_list_ui.py
@@ -1,7 +1,6 @@
 """Contains base classes for UI elements that deal with lists of entries, that can be scrolled through using arrow keys.
 Best example of such an element is a Menu element - it has menu entries you can scroll through, which execute a callback when you click on them. """
 
-import logging
 from copy import copy
 from threading import Event
 from time import sleep
@@ -9,10 +8,12 @@ from time import sleep
 from PIL import ImageFont
 from luma.core.render import canvas as luma_canvas
 
+from helpers.logger import setup_logger
 from utils import to_be_foreground, clamp_list_index
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
+import logging
+
+logger = setup_logger(__name__, logging.WARNING)
 
 #Documentation building process has problems with this import
 try:

--- a/ui/char_input.py
+++ b/ui/char_input.py
@@ -1,5 +1,6 @@
 from time import sleep
-import logging
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 import string
 
@@ -88,7 +89,7 @@ class CharArrowKeysInput():
 
     def to_foreground(self):
         """ Is called when ``activate()`` method is used, sets flags and performs all the actions so that UI element can display its contents and receive keypresses. Also, refreshes the screen."""
-        logging.info("{0} enabled".format(self.name))    
+        logger.info("{0} enabled".format(self.name))    
         self.in_foreground = True
         self.refresh()
         self.set_keymap()
@@ -97,13 +98,13 @@ class CharArrowKeysInput():
         """ A method which is called when input element needs to start operating. Is blocking, sets up input&output devices, renders the element and waits until self.in_background is False, while menu callbacks are executed from the input device thread.
         This method returns the selected value if KEY_ENTER was pressed, thus accepting the selection.
         This method returns None when the UI element was exited by KEY_LEFT and thus the value was not accepted. """
-        logging.info("{0} activated".format(self.name))    
+        logger.info("{0} activated".format(self.name))    
         self.o.cursor()
         self.to_foreground() 
         while self.in_foreground: #All the work is done in input callbacks
             sleep(0.1)
         self.o.noCursor()
-        logging.debug(self.name+" exited")
+        logger.debug(self.name+" exited")
         if self.cancel_flag:
             return None
         else:
@@ -112,15 +113,15 @@ class CharArrowKeysInput():
     def deactivate(self):
         """ Deactivates the UI element, exiting it and thus making activate() return."""
         self.in_foreground = False
-        logging.info("{0} deactivated".format(self.name))    
+        logger.info("{0} deactivated".format(self.name))    
 
     def print_value(self):
         """ A debug method. Useful for hooking up to an input event so that you can see current value. """
-        logging.info(self.value)
+        logger.info(self.value)
 
     def print_name(self):
         """ A debug method. Useful for hooking up to an input event so that you can see which UI element is currently processing input events. """
-        logging.info("{0} active".format(self.name))    
+        logger.info("{0} active".format(self.name))    
 
     @to_be_foreground
     def move_up(self):
@@ -180,13 +181,13 @@ class CharArrowKeysInput():
     def accept_value(self):
         """Selects the currently active number value, making activate() return it."""
         self.check_for_backspace()
-        logging.debug("Value accepted")
+        logger.debug("Value accepted")
         self.deactivate()
 
     @to_be_foreground
     def exit(self):
         """Exits discarding all the changes to the value."""
-        logging.debug("{} exited without changes".format(self.name))
+        logger.debug("{} exited without changes".format(self.name))
         self.cancel_flag = True
         self.deactivate()
 
@@ -234,4 +235,4 @@ class CharArrowKeysInput():
     def refresh(self):
         self.o.setCursor(1, self.position-self.first_displayed_char)
         self.o.display_data(*self.get_displayed_data())
-        logging.debug("{}: refreshed data on display".format(self.name))
+        logger.debug("{}: refreshed data on display".format(self.name))

--- a/ui/checkbox.py
+++ b/ui/checkbox.py
@@ -1,5 +1,6 @@
 from copy import copy
-import logging
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 from base_list_ui import BaseListUIElement, TextView, EightPtView, SixteenPtView, to_be_foreground
 
@@ -69,7 +70,7 @@ class Checkbox(BaseListUIElement):
     def select_entry(self):
         """ Changes the current element's state to the opposite.
         |Is typically used as a callback from input event processing thread. Afterwards, refreshes the screen."""
-        logging.debug("element selected")
+        logger.debug("element selected")
         if len(self.contents[self.pointer]) > 2 and self.contents[self.pointer][2] == self.exit_entry[2]:
             self.accepted = True
             self.deactivate()
@@ -88,7 +89,7 @@ class Checkbox(BaseListUIElement):
         self.states = [element[2] if len(element)>2 else self.default_state for element in self.contents]
         self.contents.append(self.exit_entry)
         self.states.append(False) #For the final button, to maintain "len(states) == len(self.contents)"
-        logging.debug("{}: menu contents processed".format(self.name))
+        logger.debug("{}: menu contents processed".format(self.name))
 
 
 class CheckboxRenderingMixin():
@@ -140,7 +141,7 @@ class CheckboxRenderingMixin():
             return entry
         else:
             raise Exception("Entry labels have to be either strings or lists of strings, found: {}, type: {}".format(entry, type(entry)))
-        logging.debug("Rendered entry: {}".format(rendered_entry))
+        logger.debug("Rendered entry: {}".format(rendered_entry))
         return rendered_entry
 
 class ChEightPtView(CheckboxRenderingMixin, EightPtView):

--- a/ui/config_manager.py
+++ b/ui/config_manager.py
@@ -4,6 +4,10 @@ import logging
 import traceback
 import collections
 
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.WARNING)
+
 _UI_CONFIG_MANAGER = None
 
 def get_ui_config_manager():
@@ -56,9 +60,9 @@ class UIConfigManager():
         file_path = os.path.join(path, self.base_config_name)
         try:
             base_config = self.load_config(file_path)
-        except:
-            print("Exception while loading base config!".format(file_path))
-            traceback.print_exc()
+        except Exception as e:
+            logger.error("Exception while loading base config!".format(file_path))
+            logger.exception(e)
             base_config = {}
         user_configs = []
         for file in files:
@@ -69,9 +73,9 @@ class UIConfigManager():
             file_path = os.path.join(path, file)
             try:
                 config = self.load_config(file_path)
-            except:
-                print("Exception while loading {} config".format(file_path))
-                traceback.print_exc()
+            except Exception as e:
+                logger.error("Exception while loading {} config".format(file_path))
+                logger.exception(e)
             else:
                 base_config = self.update_config(base_config, config)
         self.global_config = base_config

--- a/ui/config_manager.py
+++ b/ui/config_manager.py
@@ -1,12 +1,12 @@
 import os
 import json
-import logging
+
 import traceback
 import collections
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 _UI_CONFIG_MANAGER = None
 

--- a/ui/dialog.py
+++ b/ui/dialog.py
@@ -1,9 +1,9 @@
 from time import sleep
-import logging
 
-from helpers.logger import setup_logger
 
-logger = setup_logger(__name__, logging.INFO)
+from helpers import setup_logger
+
+logger = setup_logger(__name__, "info")
 
 class DialogBox():
     """Implements a dialog box with given values (or some default ones if chosen)."""

--- a/ui/dialog.py
+++ b/ui/dialog.py
@@ -1,8 +1,9 @@
 from time import sleep
 import logging
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.INFO)
 
 class DialogBox():
     """Implements a dialog box with given values (or some default ones if chosen)."""

--- a/ui/experimental/keypad_input.py
+++ b/ui/experimental/keypad_input.py
@@ -1,6 +1,7 @@
 from time import sleep
 from math import ceil
-import logging
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 from ui.utils import to_be_foreground
 
@@ -38,7 +39,7 @@ class NumberKeypadInputLayer():
 
     def to_foreground(self):
         """ Is called when ``activate()`` method is used, sets flags and performs all the actions so that UI element can display its contents and receive keypresses. Also, refreshes the screen."""
-        logging.info("{0} enabled".format(self.name))    
+        logger.info("{0} enabled".format(self.name))    
         self.in_foreground = True
         self.refresh()
         self.set_keymap()
@@ -47,18 +48,18 @@ class NumberKeypadInputLayer():
         """ A method which is called when input element needs to start operating. Is blocking, sets up input&output devices, renders the element and waits until self.in_background is False, while menu callbacks are executed from the input device thread.
         This method returns the selected value if KEY_ENTER was pressed, thus accepting the selection.
         This method returns None when the UI element was exited by KEY_LEFT and thus the value was not accepted. """
-        logging.info("{0} activated".format(self.name))    
+        logger.info("{0} activated".format(self.name))    
         self.to_foreground() 
         while self.in_foreground: #All the work is done in input callbacks
             sleep(0.1)
         self.i.remove_streaming()
-        logging.debug(self.name+" exited")
+        logger.debug(self.name+" exited")
         return self.value
 
     def deactivate(self):
         """ Deactivates the UI element, exiting it and thus making activate() return."""
         self.in_foreground = False
-        logging.info("{0} deactivated".format(self.name))    
+        logger.info("{0} deactivated".format(self.name))    
 
     def process_keycode(self, key_name, *args):
         header = "KEY_"
@@ -73,11 +74,11 @@ class NumberKeypadInputLayer():
 
     def print_value(self):
         """ A debug method. Useful for hooking up to an input event so that you can see current value. """
-        logging.info(self.value)
+        logger.info(self.value)
 
     def print_name(self):
         """ A debug method. Useful for hooking up to an input event so that you can see which UI element is currently processing input events. """
-        logging.info("{0} active".format(self.name))    
+        logger.info("{0} active".format(self.name))    
 
     def generate_keymap(self):
         for key in self.keymap:
@@ -127,4 +128,4 @@ class NumberKeypadInputLayer():
     @to_be_foreground
     def refresh(self):
         self.o.display_data(*self.get_displayed_data())
-        logging.debug("{}: refreshed data on display".format(self.name))
+        logger.debug("{}: refreshed data on display".format(self.name))

--- a/ui/listbox.py
+++ b/ui/listbox.py
@@ -1,4 +1,5 @@
-import logging
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 from base_list_ui import BaseListUIElement, to_be_foreground
 
@@ -49,6 +50,6 @@ class Listbox(BaseListUIElement):
     def select_entry(self):
         """ Gets the currently specified entry's index and sets it as selected_entry attribute.
         |Is typically used as a callback from input event processing thread."""
-        logging.debug("entry selected")
+        logger.debug("entry selected")
         self.selected_entry = self.pointer
         self.deactivate()

--- a/ui/menu.py
+++ b/ui/menu.py
@@ -1,4 +1,5 @@
-import logging
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 from traceback import print_exc
 
 from base_list_ui import BaseListBackgroundableUIElement, to_be_foreground
@@ -71,7 +72,7 @@ class Menu(BaseListBackgroundableUIElement):
         |Is typically used as a callback from input event processing thread.
         |After callback's execution is finished, sets the keymap again and refreshes the screen.
         |If MenuExitException is returned from the callback, exits menu."""
-        logging.debug("entry selected")
+        logger.debug("entry selected")
         self.to_background()
         entry = self.contents[self.pointer]
         if len(entry) > 1:

--- a/ui/number_input.py
+++ b/ui/number_input.py
@@ -1,6 +1,7 @@
 from time import sleep
 from copy import copy
-import logging
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 from ui.utils import to_be_foreground
 
@@ -53,7 +54,7 @@ class IntegerAdjustInput():
 
     def to_foreground(self):
         """ Is called when ``activate()`` method is used, sets flags and performs all the actions so that UI element can display its contents and receive keypresses. Also, refreshes the screen."""
-        logging.info("{0} enabled".format(self.name))    
+        logger.info("{0} enabled".format(self.name))    
         self.in_foreground = True
         self.refresh()
         self.set_keymap()
@@ -62,25 +63,25 @@ class IntegerAdjustInput():
         """ A method which is called when input element needs to start operating. Is blocking, sets up input&output devices, renders the UI element and waits until self.in_background is False, while callbacks are executed from the input device thread.
         This method returns the selected number if KEY_ENTER was pressed, thus accepting the selection.
         This method returns None when the UI element was exited by KEY_LEFT and thus it's assumed changes to the number were not accepted."""
-        logging.info("{0} activated".format(self.name))    
+        logger.info("{0} activated".format(self.name))    
         self.to_foreground() 
         while self.in_foreground: #All the work is done in input callbacks
             sleep(0.1)
-        logging.debug(self.name+" exited")
+        logger.debug(self.name+" exited")
         return self.selected_number
 
     def deactivate(self):
         """ Deactivates the UI element, exiting it and thus making activate() return."""
         self.in_foreground = False
-        logging.info("{0} deactivated".format(self.name))    
+        logger.info("{0} deactivated".format(self.name))    
 
     def print_number(self):
         """ A debug method. Useful for hooking up to an input event so that you can see current number value. """
-        logging.info(self.number)
+        logger.info(self.number)
 
     def print_name(self):
         """ A debug method. Useful for hooking up to an input event so that you can see which UI element is currently processing input events. """
-        logging.info("{0} active".format(self.name))    
+        logger.info("{0} active".format(self.name))    
 
     @to_be_foreground
     def decrement(self):
@@ -97,21 +98,21 @@ class IntegerAdjustInput():
     @to_be_foreground
     def reset(self):
         """Resets the number, setting it to the number passed to the constructor."""
-        logging.debug("Number reset")
+        logger.debug("Number reset")
         self.number = self.initial_number
         self.refresh()    
 
     @to_be_foreground
     def select_number(self):
         """Selects the currently active number value, making activate() return it."""
-        logging.debug("Number accepted")
+        logger.debug("Number accepted")
         self.selected_number = self.number
         self.deactivate()
 
     @to_be_foreground
     def exit(self):
         """Exits discarding all the changes to the number."""
-        logging.debug("{} exited without changes".format(self.name))
+        logger.debug("{} exited without changes".format(self.name))
         self.deactivate()
 
     def generate_keymap(self):
@@ -137,10 +138,10 @@ class IntegerAdjustInput():
 
     @to_be_foreground
     def refresh(self):
-        logging.debug("{0}: refreshed data on display".format(self.name))
+        logger.debug("{0}: refreshed data on display".format(self.name))
         self.display_callback(*self.get_displayed_data())
 
     def set_display_callback(self, callback):
-        logging.debug("{0}: display callback set".format(self.name))
+        logger.debug("{0}: display callback set".format(self.name))
         self.display_callback = callback
 

--- a/ui/numpad_input.py
+++ b/ui/numpad_input.py
@@ -1,14 +1,14 @@
 from time import sleep
 from copy import copy
-import logging
+
 from functools import wraps
 from threading import Lock
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui.utils import to_be_foreground, check_value_lock
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 def check_position_overflow(condition):
     """Returns a decorator which can check for different ways of "self.position" counter overflow """
     def decorator(func):

--- a/ui/numpad_input.py
+++ b/ui/numpad_input.py
@@ -4,9 +4,11 @@ import logging
 from functools import wraps
 from threading import Lock
 
+from helpers.logger import setup_logger
 from ui.utils import to_be_foreground, check_value_lock
 
 
+logger = setup_logger(__name__, logging.WARNING)
 def check_position_overflow(condition):
     """Returns a decorator which can check for different ways of "self.position" counter overflow """
     def decorator(func):
@@ -138,7 +140,7 @@ class NumpadCharInput():
         #This function processes all keycodes that are not in the keymap - such as number keycodes
         header = "KEY_"
         key = key_name[len(header):]
-        if self.debug: print("Received "+key_name)
+        if self.debug: logger.debug("Received "+key_name)
         if key in self.mapping.keys():
             #It's one of the keys we can process
             #NO INSERT IN MIDDLE/START SUPPORT

--- a/ui/path_picker.py
+++ b/ui/path_picker.py
@@ -1,9 +1,10 @@
 import os
-import logging
 
 from base_list_ui import BaseListBackgroundableUIElement, to_be_foreground
 from menu import Menu, MenuExitException
 from printer import Printer
+from helpers import setup_logger
+logger = setup_logger(__name__, "warning")
 
 class PathPicker(BaseListBackgroundableUIElement):
 
@@ -50,7 +51,7 @@ class PathPicker(BaseListBackgroundableUIElement):
         |After callback's execution is finished, sets the keymap again and refreshes the screen.
         |If menu has no elements, exits the menu.
         |If MenuExitException is returned from the callback, exits menu, too."""
-        logging.debug("element selected")
+        logger.debug("element selected")
         if len(self.contents) > 0:
             self.to_background()
             self.contents[self.pointer][1]()

--- a/ui/refresher.py
+++ b/ui/refresher.py
@@ -2,10 +2,10 @@ import logging
 from threading import Event
 from time import sleep
 
+from helpers.logger import setup_logger
 from ui.utils import to_be_foreground
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger = setup_logger(__name__, logging.INFO)
 
 
 class Refresher(object):

--- a/ui/refresher.py
+++ b/ui/refresher.py
@@ -1,11 +1,11 @@
-import logging
+
 from threading import Event
 from time import sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui.utils import to_be_foreground
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 
 class Refresher(object):

--- a/ui/scrollable_element.py
+++ b/ui/scrollable_element.py
@@ -1,17 +1,17 @@
 from __future__ import division
 
-import logging
+
 from textwrap import wrap
 from time import sleep, time
 
 from PIL.ImageDraw import ImageDraw
 from luma.core.render import canvas
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui.utils import to_be_foreground, clamp
 
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 
 class Scrollbar(object):

--- a/ui/scrollable_element.py
+++ b/ui/scrollable_element.py
@@ -7,10 +7,11 @@ from time import sleep, time
 from PIL.ImageDraw import ImageDraw
 from luma.core.render import canvas
 
+from helpers.logger import setup_logger
 from ui.utils import to_be_foreground, clamp
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.WARNING)
+
+logger = setup_logger(__name__, logging.WARNING)
 
 
 class Scrollbar(object):

--- a/ui/tests/test_checkbox.py
+++ b/ui/tests/test_checkbox.py
@@ -4,14 +4,15 @@ from mock import patch, Mock
 import logging
 import os
 import sys
+
+from helpers.logger import setup_logger
+from ui import Checkbox
+
 os.sys.path.append(os.path.dirname(os.path.abspath('.')))
 
-from checkbox import Checkbox
-
 #set up logging
-LOG_FORMAT = '%(levelname)s %(asctime)-15s %(name)s  %(message)s'
-logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
-logger = logging.getLogger(__name__)
+
+logger = setup_logger(__name__, logging.WARNING)
 
 
 def get_mock_input():

--- a/ui/tests/test_checkbox.py
+++ b/ui/tests/test_checkbox.py
@@ -1,18 +1,18 @@
 """test for Checkbox"""
 import unittest
 from mock import patch, Mock
-import logging
+
 import os
 import sys
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui import Checkbox
 
 os.sys.path.append(os.path.dirname(os.path.abspath('.')))
 
 #set up logging
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 
 def get_mock_input():

--- a/ui/tests/test_config_manager.py
+++ b/ui/tests/test_config_manager.py
@@ -1,11 +1,11 @@
 """test for Checkbox"""
 import unittest
 from mock import patch, Mock
-import logging
+
 import os
 import sys
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 from ui.config_manager import UIConfigManager
 
 os.sys.path.append(os.path.dirname(os.path.abspath('.')))
@@ -14,7 +14,7 @@ os.sys.path.append(os.path.dirname(os.path.abspath('.')))
 LOG_FORMAT = '%(levelname)s %(asctime)-15s %(name)s  %(message)s'
 logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
 
-logger = setup_logger(__name__, logging.WARNING)
+logger = setup_logger(__name__, "warning")
 
 
 class TestUIConfigManager(unittest.TestCase):

--- a/ui/tests/test_config_manager.py
+++ b/ui/tests/test_config_manager.py
@@ -4,14 +4,17 @@ from mock import patch, Mock
 import logging
 import os
 import sys
-os.sys.path.append(os.path.dirname(os.path.abspath('.')))
 
-from config_manager import UIConfigManager
+from helpers.logger import setup_logger
+from ui.config_manager import UIConfigManager
+
+os.sys.path.append(os.path.dirname(os.path.abspath('.')))
 
 #set up logging
 LOG_FORMAT = '%(levelname)s %(asctime)-15s %(name)s  %(message)s'
 logging.basicConfig(format=LOG_FORMAT, level=logging.INFO)
-logger = logging.getLogger(__name__)
+
+logger = setup_logger(__name__, logging.WARNING)
 
 
 class TestUIConfigManager(unittest.TestCase):

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -1,10 +1,10 @@
-import logging
+
 from functools import wraps
 from time import time, sleep
 
-from helpers.logger import setup_logger
+from helpers import setup_logger
 
-logger = setup_logger(__name__, logging.INFO)
+logger = setup_logger(__name__, "info")
 
 
 def to_be_foreground(func):

--- a/ui/utils.py
+++ b/ui/utils.py
@@ -2,8 +2,9 @@ import logging
 from functools import wraps
 from time import time, sleep
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+from helpers.logger import setup_logger
+
+logger = setup_logger(__name__, logging.INFO)
 
 
 def to_be_foreground(func):


### PR DESCRIPTION
**Purpose**
deal with #38 and unify logging

**Implementation**
- I added a `setup_logger(name, level)` functions in the helpers.
- All files now call it to get a logger
Some instances of `print()` weren't replaced :
- When `print` is used in `__name__=='__main__'` stuff as a quick-debug function
- When `print` was commented out in the original file
The last point may need to change, please advise.