### PR TITLE
Clock redesign

### DIFF
--- a/apps/clock/main.py
+++ b/apps/clock/main.py
@@ -1,20 +1,69 @@
-menu_name = "Clock" 
+from __future__ import division
 
+import math
 from datetime import datetime
 
+from luma.core.render import canvas
+
+from apps import ZeroApp
 from ui import Refresher
-
-def show_time():
-    now = datetime.now()
-    return [now.strftime("%H:%M:%S").center(o.cols), now.strftime("%Y-%m-%d").center(o.cols)]
-
-i = None; o = None
-
-def callback():
-    Refresher(show_time, i, o, 1, name="Clock refresher").activate()
-
-def init_app(input, output):
-    global i, o
-    i = input; o = output #Getting references to output and input device objects and saving them as globals
+from ui.loading_indicators import CenteredTextRenderer
 
 
+class ClockApp(ZeroApp, Refresher, CenteredTextRenderer):
+
+    def __init__(self, i, o, *args, **kwargs):
+        super(ClockApp, self).__init__(i, o)
+        self.menu_name = "Clock"
+        self.refresher = Refresher(self.on_refresh, i, o)
+
+    def on_refresh(self):
+        now = datetime.now()
+        c = canvas(self.o.device)
+        c.__enter__()
+        x, y = c.device.size
+        radius = min(x, y) / 4
+        x, y = self.get_center(self.o.device.size)
+        draw = c.draw
+        time_str = now.strftime("%H:%M:%S")
+        bounds = self.get_centered_text_bounds(draw, time_str, self.o.device.size)
+        draw.text((bounds.left, 0), time_str, fill="white")
+
+        draw.ellipse((x - radius, y - radius, x + radius, y + radius), fill=False, outline="white")
+        self.draw_needle(draw, 60 - now.second / 60, radius, x, y, 1)
+        self.draw_needle(draw, 60 - now.minute / 60, radius, x, y, 1)
+        self.draw_needle(draw, 24 - now.hour / 24, radius / 2, x, y, 1)
+
+        return c.image
+
+    def draw_needle(self, draw, progress, radius, x, y, width):
+        # type: (ImageDraw, float, float, float, float, int) -> None
+        hour_angle = math.pi * 2 * progress + math.pi
+        draw.line(
+            (
+                x,
+                y,
+                x + radius * math.sin(hour_angle),
+                y + radius * math.cos(hour_angle)
+            ),
+            width=width,
+            fill=True
+        )
+
+    def on_start(self):
+        super(ClockApp, self).on_start()
+        self.refresher.activate()
+
+# def show_time():
+#     now = datetime.now()
+#     return [now.strftime("%H:%M:%S").center(o.cols), now.strftime("%Y-%m-%d").center(o.cols)]
+
+# i = None; o = None
+#
+# def callback():
+#     Refresher(show_time, i, o, 1, name="Clock refresher").activate()
+#
+# def init_app(input, output):
+#     global i, o
+#     i = input; o = output #Getting references to output and input device objects and saving them as globals
+#

--- a/input/drivers/pygame_input.py
+++ b/input/drivers/pygame_input.py
@@ -1,4 +1,4 @@
-
+import logging
 from time import sleep
 
 import pygame

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -42,6 +42,10 @@ class CenteredTextRenderer(object):
         dw, dh = device_size
         return Rect(dw / 2 - w / 2, dh / 2 - h / 2, dw / 2 + w / 2, dh / 2 + h / 2)
 
+    @staticmethod
+    def get_center(device_size):
+        # type: (tuple) -> tuple
+        return device_size[0] / 2, device_size[1] / 2
 
 # ========================= abstract classes =========================
 

--- a/ui/refresher.py
+++ b/ui/refresher.py
@@ -2,6 +2,8 @@
 from threading import Event
 from time import sleep
 
+import PIL
+
 from helpers import setup_logger
 from ui.utils import to_be_foreground
 
@@ -129,6 +131,9 @@ class Refresher(object):
         elif isinstance(data_to_display, tuple):
             #Passed a tuple. Let's convert it into a list!
             data_to_display = list(data_to_display)
+        elif isinstance(data_to_display, PIL.Image.Image):
+            self.o.display_image(data_to_display)
+            return
         elif not isinstance(data_to_display, list):
             raise ValueError("refresh_function returned an unsupported type: {}!".format(type(data_to_display)))
         self.o.display_data(*data_to_display)


### PR DESCRIPTION
**Purpose**
Adds a new design to the clock so it looks like an actual clock (with needles and all)

**Implementation**
`Refresher` now handles its `refresh_function` returning a `PIL.Image` object so we can do more complex drawings as part of a refresher (as oposed to text/list only).
