### PR TITLE
63 script app readability

### DIFF
--- a/apps/example_apps/text_reader/main.py
+++ b/apps/example_apps/text_reader/main.py
@@ -27,8 +27,8 @@ If the implementation is easy to explain, it may be a good idea.
 Namespaces are one honking great idea - let's do more of those!
 """
         self.menu_name = "TextReader test app"
-        self.textreader = TextReader(zen_of_python, i, o, self.menu_name)
+        self.text_reader = TextReader(zen_of_python, i, o, self.menu_name)
 
     def on_start(self):
         super(TextReaderExample, self).on_start()
-        self.textreader.activate()
+        self.text_reader.activate()

--- a/apps/scripts/main.py
+++ b/apps/scripts/main.py
@@ -62,7 +62,7 @@ def call_external(script_list, shell=False):
             return
         answer = DialogBox("yn", i, o, message="Show output?").activate()
         if answer:
-            TextReader(output, i, o, hide_scrollbar=True).activate()
+            TextReader(output, i, o, autohide_scrollbars=True, h_scroll=True).activate()
 
 
 def call_by_path():

--- a/apps/scripts/main.py
+++ b/apps/scripts/main.py
@@ -2,7 +2,7 @@ import os
 from subprocess import check_output, CalledProcessError, STDOUT
 
 from helpers import read_or_create_config, local_path_gen
-from ui import Menu, Printer, DialogBox, format_for_screen as ffs, PathPicker, NumpadCharInput
+from ui import Menu, Printer, DialogBox, PathPicker, NumpadCharInput, TextReader
 
 menu_name = "Scripts"  # App name as seen in main menu while using the system
 
@@ -36,6 +36,8 @@ def call_external(script_list, shell=False):
     else:
         script_path = os.path.split(script_list[0])[1]
     Printer("Calling {}".format(script_path), i, o, 1)
+
+    output = None
     try:
         output = check_output(script_list, stderr=STDOUT, shell=shell)
     except OSError as e:
@@ -47,7 +49,7 @@ def call_external(script_list, shell=False):
             Printer(["Unknown format,", "forgot header?"], i, o, 1)
         else:
             error_data = ["Unknown error", ""]
-            error_data += ffs(repr(e), o.cols)
+            error_data += repr(e)
             Printer(error_data, i, o, 1)
         output = ""
     except CalledProcessError as e:
@@ -60,7 +62,7 @@ def call_external(script_list, shell=False):
             return
         answer = DialogBox("yn", i, o, message="Show output?").activate()
         if answer:
-            Printer(ffs(output, o.cols, False), i, o, 5, True)
+            TextReader(output, i, o, hide_scrollbar=True).activate()
 
 
 def call_by_path():

--- a/apps/scripts/main.py
+++ b/apps/scripts/main.py
@@ -1,8 +1,15 @@
-menu_name = "Scripts" #App name as seen in main menu while using the system
+import os
+from subprocess import check_output, CalledProcessError, STDOUT
+
+from helpers import read_or_create_config, local_path_gen
+from ui import Menu, Printer, DialogBox, format_for_screen as ffs, PathPicker, NumpadCharInput
+
+menu_name = "Scripts"  # App name as seen in main menu while using the system
 
 scripts_dir = "s/"
 config_filename = "config.json"
-default_config = """[
+default_config = """
+[
  {"path":"./s/login.sh",
   "name":"Hotspot login"},
  {"path":"./s/dmesg.sh",
@@ -18,20 +25,13 @@ default_config = """[
   "args":["http://www.google.com"]}
 ]"""
 
-from subprocess import check_output, CalledProcessError, STDOUT
-from time import sleep
-import os, sys, shlex
-
-from helpers import read_or_create_config, local_path_gen
-from ui import Menu, Printer, DialogBox, format_for_screen as ffs, PathPicker, NumpadCharInput
-
 local_path = local_path_gen(__name__)
 config_path = local_path(config_filename)
-config = read_or_create_config(config_path, default_config, menu_name+" app")
+config = read_or_create_config(config_path, default_config, menu_name + " app")
 
 
 def call_external(script_list, shell=False):
-    if shell == True:
+    if shell:
         script_path = script_list.split(' ')[0]
     else:
         script_path = os.path.split(script_list[0])[1]
@@ -59,8 +59,9 @@ def call_external(script_list, shell=False):
         if not output:
             return
         answer = DialogBox("yn", i, o, message="Show output?").activate()
-        if answer == True:
+        if answer:
             Printer(ffs(output, o.cols, False), i, o, 5, True)
+
 
 def call_by_path():
     path = PathPicker("/", i, o).activate()
@@ -68,15 +69,16 @@ def call_by_path():
         return
     args = NumpadCharInput(i, o, message="Arguments:", name="Script argument input").activate()
     if args is not None:
-        path = path+" "+args
+        path = path + " " + args
     call_external(path, shell=True)
-        
+
+
 def call_command():
     command = NumpadCharInput(i, o, message="Command:", name="Script command input").activate()
     if command is None:
         return
     call_external(command, shell=True)
-        
+
 
 def callback():
     script_menu_contents = [["Script by path", call_by_path],
@@ -90,7 +92,7 @@ def callback():
             scripts_in_config.append(script_path)
         args = script_def["args"] if "args" in script_def else []
         script_name = script_def["name"] if "name" in script_def else os.path.split(script_path)[1]
-        script_list = [script_path]+args
+        script_list = [script_path] + args
         script_menu_contents.append([script_name, lambda x=script_list: call_external(x)])
     other_scripts = os.listdir(local_path(scripts_dir))
     for script in other_scripts:
@@ -99,8 +101,12 @@ def callback():
             script_menu_contents.append([os.path.join(scripts_dir, script), lambda x=relpath: call_external([x])])
     Menu(script_menu_contents, i, o, "Script menu").activate()
 
-i = None; o = None
 
-def init_app(input, output):
+i = None
+o = None
+
+
+def init_app(input_obj, output_obj):
     global i, o
-    i = input; o = output
+    i = input_obj
+    o = output_obj

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,9 +1,13 @@
 import logging
 
+
 def setup_logger(logger_name, log_level="warning"):
     # type: (str, str) -> logging.Logger
-    # todo : read level from config here
-    logger_level_attr = getattr(logging, log_level.upper())
+    try:
+        logger_level_attr = getattr(logging, log_level.upper())
+    except AttributeError:
+        logger_level_attr = logging.WARNING
+
     logger = logging.getLogger(logger_name)
     logger.setLevel(logger_level_attr)
     return logger

--- a/ui/scrollable_element.py
+++ b/ui/scrollable_element.py
@@ -12,15 +12,15 @@ from ui.utils import to_be_foreground, clamp
 logger = setup_logger(__name__, "warning")
 
 
-class Scrollbar(object):
-    def __init__(self, o, width=2, min_height=1, margin=1, color="white"):
+class VerticalScrollbar(object):
+    def __init__(self, o, width=1, min_size=1, margin=1, color="white"):
         self.screen = o
         self._width = width
         self.margin = margin
-        self.min_height = min_height
+        self.min_size = min_size
         self.color = color
         self._progress = 0  # 0-1 range, 0 is top, 1 is bottom
-        self.height = 0  # 0-1 range, 0 is minimum size, 1 is whole screen
+        self.size = 0  # 0-1 range, 0 is minimum size, 1 is whole screen
 
     def draw(self, draw):
         # type: (ImageDraw) -> None
@@ -28,12 +28,12 @@ class Scrollbar(object):
         draw.rectangle(rect, fill=self.color)
 
     def get_coords(self):
-        height_px = self.screen.height * self.height
-        height_px = max(height_px, self.min_height)  # so we always have something to show
+        height_px = self.screen.height * self.size
+        height_px = max(height_px, self.min_size)  # so we always have something to show
         y_pos = self.progress * self.screen.height
         rect = (
             self.margin, y_pos,
-            self._width, y_pos + height_px
+            self.margin + self._width, y_pos + height_px
         )
         return rect
 
@@ -51,22 +51,74 @@ class Scrollbar(object):
         self._progress = clamp(value, 0, 1)
 
 
-class HideableScrollbar(Scrollbar):
+class HorizontalScrollbar(VerticalScrollbar):
 
-    def __init__(self, o, width=2, min_height=1, margin=1, color="white", fade_time=1.5):
-        super(HideableScrollbar, self).__init__(o, width, min_height, margin, color)
+    def get_coords(self):
+        width_px = self.screen.width * self.size
+        width_px = max(width_px, self.min_size)
+        x_pos = self.progress * self.screen.width
+        rect = (
+            x_pos, self.screen.height - self._width - self.margin,
+            x_pos + width_px, self.screen.height - self.margin
+        )
+        return rect
+
+    def draw(self, draw):
+        rect = self.get_coords()
+        draw.rectangle(
+            self.get_background_coords(),
+            fill="black",
+            outline="black",
+        )
+        draw.rectangle(rect, fill=self.color)
+
+    def get_background_coords(self):
+        return 0, self.screen.height - self.width, self.screen.width, self.screen.height
+
+
+class HideableVerticalScrollbar(VerticalScrollbar):
+
+    def __init__(self, o, width=1, min_size=1, margin=1, color="white", fade_time=1):
+        super(HideableVerticalScrollbar, self).__init__(o, width, min_size, margin, color)
         self.fade_time = fade_time
         self.last_activity = -fade_time
 
     def draw(self, draw):
         # type: (ImageDraw) -> None
         rect = self.get_coords()
-        color = self.color if time() - self.last_activity < self.fade_time else False
-        draw.rectangle(rect, fill=color, outline=color)
+        self.update_color()
+        draw.rectangle(rect, fill=self.color, outline=self.color)
+
+    def update_color(self):
+        self.color = "white" if time() - self.last_activity < self.fade_time else False
 
     # noinspection PyMethodOverriding
-    @Scrollbar.progress.setter
+    @VerticalScrollbar.progress.setter
     def progress(self, value):
+        if value == self.progress:
+            return
+        self.last_activity = time()
+        self._progress = clamp(value, 0, 1)
+
+
+class HideableHorizontalScrollbar(HorizontalScrollbar, HideableVerticalScrollbar):
+
+    def __init__(self, o, width=1, min_size=1, margin=1, color="white", fade_time=1):
+        HorizontalScrollbar.__init__(self, o, width, min_size, margin, color)
+        HideableVerticalScrollbar.__init__(self, o, width, min_size, margin, color, fade_time)
+
+    def get_coords(self):
+        return HorizontalScrollbar.get_coords(self)
+
+    def draw(self, draw):
+        self.update_color()
+        return HorizontalScrollbar.draw(self, draw)
+
+    # noinspection PyMethodOverriding
+    @VerticalScrollbar.progress.setter
+    def progress(self, value):
+        if value == self.progress:
+            return
         self.last_activity = time()
         self._progress = clamp(value, 0, 1)
 
@@ -75,7 +127,7 @@ class TextReader(object):
     """A vertical-scrollable ui element used to read text"""
 
     # todo : documentation
-    def __init__(self, text, i, o, name="TextReader", sleep_interval=1, scroll_speed=2, hide_scrollbar=False,
+    def __init__(self, text, i, o, name="TextReader", sleep_interval=1, scroll_speed=2, autohide_scrollbars=True,
                  h_scroll=None):
         self.i = i
         self.o = o
@@ -84,57 +136,62 @@ class TextReader(object):
         self.scroll_speed = scroll_speed
         self.keymap = dict
 
-        if hide_scrollbar:
-            self.scrollbar = HideableScrollbar(self.o, width=2, margin=2)
+        if autohide_scrollbars:
+            self.v_scrollbar = HideableVerticalScrollbar(self.o, margin=2)
+            self.h_scrollbar = HideableHorizontalScrollbar(self.o, margin=2)
         else:
-            self.scrollbar = Scrollbar(self.o, width=2, margin=2)
+            self.v_scrollbar = VerticalScrollbar(self.o)
+            self.h_scrollbar = HorizontalScrollbar(self.o)
 
         char_width = self.o.charwidth if hasattr(self, "charwidth") else 8  # emulator
-        text_width = self.o.cols - (self.scrollbar.width // char_width)
+        text_width = self.o.cols - (self.v_scrollbar.width // char_width)
 
         self._content_width = max([len(line) for line in text.splitlines()])
-        self._content_height = len(text)
+        self._content_height = len(text.splitlines())
         self.horizontal_scroll = h_scroll if h_scroll is not None else self._content_width > self.o.cols
-        self._content = text.splitlines() if h_scroll else wrap(text, text_width)
+        self._content = text.splitlines() if self.horizontal_scroll else wrap(text, text_width)
 
         self.in_foreground = False
-        self.y_scroll_index = 0
-        self.x_scroll_index = 0
+        self.v_scroll_index = 0
+        self.h_scroll_index = 0
+
+        self.after_move()
 
     def activate(self):
         logger.info("{0} activated".format(self.name))
         self.to_foreground()
         while self.in_foreground:  # All the work is done in input callbacks
             sleep(self.sleep_interval)
+            self.refresh()  # needed to update the hideable scrollbars
         logger.info("{} exited".format(self.name))
         return None
 
     @to_be_foreground
     def refresh(self):
-        self.scrollbar.height = self.o.rows / len(self._content)
         text = self.get_displayed_text()
         tmp_canvas = canvas(self.o.device)
         image_drawer = tmp_canvas.__enter__()
-        self.scrollbar.draw(image_drawer)
-        self.draw_text(text, image_drawer, self.scrollbar.width)
+        self.draw_text(text, image_drawer, self.v_scrollbar.width)
+        self.v_scrollbar.draw(image_drawer)
+        self.h_scrollbar.draw(image_drawer)
 
         self.o.display_image(tmp_canvas.image)
 
         del tmp_canvas
         del image_drawer
 
-    def draw_text(self, text, draw, x_offset=2):
+    def draw_text(self, text, draw, x_offset):
         charheight = self.o.charheight if hasattr(self.o, "charheight") else 8
         for line, arg in enumerate(text):
             y = (line * charheight)
             draw.text((x_offset, y), arg, fill='white')
 
     def get_displayed_text(self):
-        start = self.x_scroll_index
+        start = self.h_scroll_index
         end = start + self.o.rows
         displayed_data = self._content[start:end]
         if self.horizontal_scroll:
-            displayed_data = [line[self.y_scroll_index:self.o.cols + self.y_scroll_index] for line in displayed_data]
+            displayed_data = [line[self.v_scroll_index:self.o.cols + self.v_scroll_index] for line in displayed_data]
 
         return displayed_data
 
@@ -166,31 +223,34 @@ class TextReader(object):
         self.in_foreground = False
 
     def move_up(self):
-        self.x_scroll_index -= self.scroll_speed
+        self.h_scroll_index -= self.scroll_speed
         self.after_move()
 
     def move_down(self):
-        self.x_scroll_index += self.scroll_speed
+        self.h_scroll_index += self.scroll_speed
         self.after_move()
 
     def move_right(self):
-        self.y_scroll_index += self.scroll_speed
+        self.v_scroll_index += self.scroll_speed
         self.after_move()
 
     def move_left(self):
-        self.y_scroll_index -= self.scroll_speed
+        self.v_scroll_index -= self.scroll_speed
         self.after_move()
 
     def page_up(self):
-        self.x_scroll_index -= self.scroll_speed * 2
+        self.h_scroll_index -= self.scroll_speed * 2
         self.after_move()
 
     def page_down(self):
-        self.x_scroll_index += self.scroll_speed * 2
+        self.h_scroll_index += self.scroll_speed * 2
         self.after_move()
 
     def after_move(self):
-        self.x_scroll_index = clamp(self.x_scroll_index, 0, len(self._content) - self.o.rows + 1)
-        self.y_scroll_index = clamp(self.y_scroll_index, 0, self._content_width - self.o.cols + 1)
-        self.scrollbar.progress = self.x_scroll_index / len(self._content)
+        self.v_scrollbar.size = self.o.rows / self._content_height
+        self.h_scrollbar.size = self.o.cols / self._content_width
+        self.h_scroll_index = clamp(self.h_scroll_index, 0, self._content_height - self.o.rows + 1)
+        self.v_scroll_index = clamp(self.v_scroll_index, 0, self._content_width - self.o.cols + 1)
+        self.v_scrollbar.progress = self.h_scroll_index / self._content_height
+        self.h_scrollbar.progress = self.v_scroll_index / self._content_width
         self.refresh()

--- a/ui/scrollable_element.py
+++ b/ui/scrollable_element.py
@@ -1,6 +1,5 @@
 from __future__ import division
 
-
 from textwrap import wrap
 from time import sleep, time
 
@@ -9,7 +8,6 @@ from luma.core.render import canvas
 
 from helpers import setup_logger
 from ui.utils import to_be_foreground, clamp
-
 
 logger = setup_logger(__name__, "warning")
 
@@ -86,7 +84,8 @@ class TextReader(object):
             self.scrollbar = HideableScrollbar(self.o, width=2, margin=2)
         else:
             self.scrollbar = Scrollbar(self.o, width=2, margin=2)
-        text_width = self.o.cols - (self.scrollbar.width // self.o.charwidth)
+        char_width = self.o.charwidth if hasattr(self, "charwidth") else 8  # emulator
+        text_width = self.o.cols - (self.scrollbar.width // char_width)
         self.content = wrap(text_content, text_width)
         self.in_foreground = False
         self.scroll_index = 0
@@ -115,7 +114,8 @@ class TextReader(object):
 
     def draw_text(self, text, draw, x_offset=2):
         for line, arg in enumerate(text):
-            y = (line * self.o.charheight)
+            charheight = self.o.charheight if hasattr(self.o, "charheight") else 8
+            y = (line * charheight)
             draw.text((x_offset, y), arg, fill='white')
 
     def get_displayed_text(self):


### PR DESCRIPTION
**Purpose**
Fix #63 by allowing TextReader to scroll horizontally as well, thus preserving formatting of lines.

**Implementation**
Adds a HorizontalScrollbar and HideableHorizontal scroll bar object.
Horizontal scroll is enabled if :
- Specified in `TextReader` ctor (`h_scroll=True`)
- Any line is longer than `device.width`

**Issues**
Scrolling left and right needs `KEY_LEFT` and `KEY_RIGHT` as inputs. So the default 'left to exit menu' behaviour is not respected. I plugged the exit on `KEY_ENTER` at the moment, but I'm open to new suggestions. Maybe, scrolling left when you're already at leftmost position ?