### PR TITLE
Fix emulator

### DIFF
--- a/emulator.py
+++ b/emulator.py
@@ -135,15 +135,15 @@ class Emulator(object):
 
     def display_data(self, *args):
         with canvas(self.device) as draw:
-            dims = (
-                self.cursor_pos[0] - 1 + 2,
-                self.cursor_pos[1] - 1,
-                self.cursor_pos[0] + self.char_width + 2,
-                self.cursor_pos[1] + self.char_height + 1,
-            )
 
             if self.cursor_enabled:
                 logger.debug('Drawing cursor with dims: %s', dims)
+                dims = (
+                    self.cursor_pos[0] - 1 + 2,
+                    self.cursor_pos[1] - 1,
+                    self.cursor_pos[0] + self.char_width + 2,
+                    self.cursor_pos[1] + self.char_height + 1,
+                )
                 draw.rectangle(dims, outline='white')
 
             args = args[:self.rows]
@@ -155,8 +155,7 @@ class Emulator(object):
                 # Passing anything except a string to draw.text will cause
                 # PIL to throw an exception.  Warn 'em here via the log.
                 if not isinstance(arg, basestring):
-                    logger.warning('emulator only likes strings fed to '
-                        'draw.text, prepare for exception')
+                    raise ValueError("*args[{}] is not a string, but a {} - unacceptable!".format(line, type(arg)))
                 y = (line * self.char_height - 1) if line != 0 else 0
                 draw.text((2, y), arg, fill='white')
                 logger.debug('after draw.text(2, %d), %s', y, arg)

--- a/emulator.py
+++ b/emulator.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python2
 
+"""
+This module is as complicated as it is because it was necessary to work
+around the fact that pygame (which this emulator is based on) doesn't
+like multi-threaded environments, in particular, it doesn't like when
+input and output are done from two different threads. For this reason,
+the pygame IO is done in a different process, and we're using
+multiprocessing.Pipe to communicate with this process. Part of the
+complexity is also the fact that nobody (including me) bothered to
+implement a two-way communication, so there's yet no way to get callable
+return values and, as a result, attribute values. If you're reading this,
+consider helping us with it - this way, we could be free from all the
+hardcoded values in EmulatorProxy =)
+"""
+
 from multiprocessing import Process, Pipe
 from time import sleep
 
@@ -12,8 +26,9 @@ from output.output import GraphicalOutputDevice, CharacterOutputDevice
 
 logger = setup_logger(__name__, "warning")
 
+# A singleton - since the same object needs to be called
+# both in the pygame output and pygame input drivers.
 __EMULATOR_PROXY = None
-
 
 def get_emulator():
     global __EMULATOR_PROXY
@@ -50,12 +65,23 @@ class EmulatorProxy(object):
 
     def __getattr__(self, name):
         # Raise an exception if the attribute being called
-        # Doesn't actually exist on the Emulator object
+        # doesn't actually exist on the Emulator object
         getattr(Emulator, name)
+        # Otherwise, return an object that imitates the requested
+        # attribute of the Emulator - for now, only callables
+        # are supported, and you can't get the result of a
+        # callable.
         return DummyCallableRPCObject(self.parent_conn, name)
 
 
 class DummyCallableRPCObject(object):
+    """
+    This is an object that allows us to call functions of the Emulator
+    that's running as another process. In the future, it might also support
+    getting attributes and passing return values (same thing, really),
+    which should also allow us to get rid of hard-coded parameters
+    in the EmulatorProxy object.
+    """
     def __init__(self, parent_conn, name):
         self.parent_conn = parent_conn
         self.__name__ = name
@@ -94,7 +120,7 @@ class Emulator(object):
         try:
             self._event_loop()
         except KeyboardInterrupt:
-            logger.info('Caught KeyboardIterrupt')
+            logger.info('Caught KeyboardInterrupt')
         except:
             logger.exception('Unknown exception during event loop')
             raise
@@ -137,7 +163,6 @@ class Emulator(object):
         with canvas(self.device) as draw:
 
             if self.cursor_enabled:
-                logger.debug('Drawing cursor with dims: %s', dims)
                 dims = (
                     self.cursor_pos[0] - 1 + 2,
                     self.cursor_pos[1] - 1,
@@ -147,10 +172,8 @@ class Emulator(object):
                 draw.rectangle(dims, outline='white')
 
             args = args[:self.rows]
-            logger.debug("type(args)=%s", type(args))
 
             for line, arg in enumerate(args):
-                logger.debug('line %s: arg=%s, type=%s', line, arg, type(arg))
                 # Emulator only:
                 # Passing anything except a string to draw.text will cause
                 # PIL to throw an exception.  Warn 'em here via the log.
@@ -158,7 +181,6 @@ class Emulator(object):
                     raise ValueError("*args[{}] is not a string, but a {} - unacceptable!".format(line, type(arg)))
                 y = (line * self.char_height - 1) if line != 0 else 0
                 draw.text((2, y), arg, fill='white')
-                logger.debug('after draw.text(2, %d), %s', y, arg)
 
     def display_image(self, image):
         self.device.display(image)

--- a/emulator.py
+++ b/emulator.py
@@ -3,12 +3,13 @@
 from multiprocessing import Process, Pipe
 from time import sleep
 
-from time import sleep
 import luma.emulator.device
 import pygame
 from luma.core.render import canvas
 
 from helpers import setup_logger
+from output.output import GraphicalOutputDevice, CharacterOutputDevice
+
 logger = setup_logger(__name__, "warning")
 
 __EMULATOR_PROXY = None
@@ -34,6 +35,8 @@ class EmulatorProxy(object):
         self.device = type("MockDevice", (), {"mode":"1", "size":(128, 64)})
         self.parent_conn, self.child_conn = Pipe()
         self.proc = Process(target=Emulator, args=(self.child_conn,))
+        self.__base_classes__ = (GraphicalOutputDevice, CharacterOutputDevice)
+        self.current_image = None
         self.proc.start()
 
     def poll_input(self, timeout=1):

--- a/emulator.py
+++ b/emulator.py
@@ -58,11 +58,11 @@ class EmulatorProxy(object):
 class DummyCallableRPCObject(object):
     def __init__(self, parent_conn, name):
         self.parent_conn = parent_conn
-        self.name = name
+        self.__name__ = name
 
     def __call__(self, *args, **kwargs):
         self.parent_conn.send({
-            'func_name': self.name,
+            'func_name': self.__name__,
             'args': args,
             'kwargs': kwargs
         })

--- a/output/drivers/pygame_emulator.py
+++ b/output/drivers/pygame_emulator.py
@@ -4,13 +4,9 @@ Allows development of sofware without ZeroPhone hardware,
 e.g. on a laptop with a USB keyboard.
 """
 
-from threading import Event
-from time import sleep
-
-from luma.core.render import canvas
-
 import emulator
 from output.output import OutputDevice
+
 from helpers import setup_logger
 logger = setup_logger(__name__, "info")
 
@@ -47,29 +43,3 @@ class Screen(OutputDevice):
 
     def __getattr__(self, name):
         return getattr(self.emulator, name)
-
-    #def display_data(self, *args):
-    #    """Displays data on display.
-    #    called from menu.py refresh() so don't remove this method
-    #    This function does the actual work of printing things to display.
-    #    ``*args`` is a list of strings,
-    #              where each string corresponds to a row of the display,
-    #              starting with 0.
-    #              Note:  the emulator does not support passing tuples, lists
-    #              or anything except comma delimited simple strings as args.
-    #    """
-    #    self.emulator.display_data(*args)
-
-    #def setCursor(self, row, col):
-    #    """
-    #    Called from menu.py refresh() so don't remove this method
-    #    Set current input cursor to ``row`` and ``column`` specified """
-    #    self.emulator.setCursor(row, col)
-
-    #def noCursor(self):
-    #    """ Turns the box cursor off """
-    #    self.emulator.noCursor()
-
-    #def cursor(self):
-    #    """ Turns the box cursor on """
-    #    self.emulator.cursor()

--- a/output/output.py
+++ b/output/output.py
@@ -1,7 +1,6 @@
-import importlib
-from copy import deepcopy
 from functools import wraps
-
+from copy import deepcopy
+import importlib
 
 # These base classes document functions that
 # different output devices are expected to have.
@@ -50,8 +49,7 @@ class OutputDevice(object):
 
     def get_proxied_method(o, proxy, method_name, sideeffect):
         method = getattr(o, method_name)
-
-        @wraps(method, ['__module__', '__doc__'])
+        @wraps(method)
         def wrapper(*args, **kwargs):
             #print("Method: "+method_name)
             sideeffect(*args, **kwargs)

--- a/output/output.py
+++ b/output/output.py
@@ -1,6 +1,7 @@
-from functools import wraps
-from copy import deepcopy
 import importlib
+from copy import deepcopy
+from functools import wraps
+
 
 # These base classes document functions that
 # different output devices are expected to have.
@@ -49,7 +50,8 @@ class OutputDevice(object):
 
     def get_proxied_method(o, proxy, method_name, sideeffect):
         method = getattr(o, method_name)
-        @wraps(method)
+
+        @wraps(method, ['__module__', '__doc__'])
         def wrapper(*args, **kwargs):
             #print("Method: "+method_name)
             sideeffect(*args, **kwargs)


### PR DESCRIPTION
# purpose
fix emulator crash since `multiple_context` merge

# status
tested on emulator
untested on hardware

# implementation
- The class `EmulatorProxy` was missing `__base_classes__`
- The wrapping function in `get_proxied_method` was trying to access `__name__` which was undefined
