### PR TITLE
[WIP] Log management through config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ config.json
 # We ship do_not_load files in some directories, but do not track user-created files
 # (only user-removed ones)
 do_not_load
+log_conf.ini

--- a/apps/settings/logging_ui.py
+++ b/apps/settings/logging_ui.py
@@ -1,0 +1,78 @@
+i = None
+o = None
+
+from collections import OrderedDict
+import logging
+
+import helpers.logger as log_system
+
+logger_alias_map = (("root","Main launcher"),
+                    ("input.input","Input system"),
+                    ("apps.app_manager","App manager"),
+                    ("context_manager","Context manager"),
+                    ("emulator","Emulator"),
+                    ("helpers.logger","Logging system"))
+
+logger_alias_map = OrderedDict(logger_alias_map)
+
+from ui import Menu, Printer, Listbox
+
+def get_logger_names():
+    return log_system.get_logger_names()
+
+def prettify_logger_names(names):
+    name_mapping = OrderedDict()
+    for name in names:
+        if name in logger_alias_map:
+            # We have a defined name for this logger
+            name_mapping[name] = logger_alias_map[name]
+        elif name.startswith("ui."):
+            # This is an UI logger
+            element_name = name[len("ui."):].capitalize()
+            name_mapping[name] = "UI - {}".format(element_name)
+        elif name.startswith("apps."):
+            # This is an app logger
+            app_name, module_name = name.rsplit(".", 2)[1:]
+            app_name = app_name.capitalize().replace("_", " ")
+            name_mapping[name] = '{} app - {}'.format(app_name, module_name)
+        elif name.startswith("input.drivers") or name.startswith("output.drivers"):
+            # This is a driver logger
+            driver_name = name.rsplit(".", 1)[1].capitalize().replace("_", " ")
+            name_mapping[name] = '{} driver'.format(driver_name)
+        else:
+            # Fallback - name is not know and we can't yet prettify it
+            name_mapping[name] = name
+    return name_mapping
+
+def get_available_levels():
+    return [ key.lower() for key in logging._levelNames.keys() if isinstance(key, basestring) ]
+
+def select_loglevel(current):
+    available_levels = get_available_levels()
+    print(current)
+    print(available_levels)
+    lb_contents = [[level.capitalize(), level] for level in available_levels]
+    lb = Listbox(lb_contents, i, o, "Loglevel selection listbox")
+    lb.start_value = available_levels.index(current.lower())
+    return lb.activate()
+
+def change_loglevel(logger_name, current_level):
+    new_level = select_loglevel(current_level)
+    if new_level is not None:
+        assert (new_level in get_available_levels())
+        log_system.LoggingConfig().set_level(logger_name, new_level)
+        log_system.LoggingConfig().reload_config()
+        print("Loglevel set!")
+
+def get_menu_contents():
+    logger_names = get_logger_names()
+    pretty_logger_names = prettify_logger_names(logger_names)
+    sorted_names = sorted(pretty_logger_names.items(), key=lambda x: x[1])
+    for i, (name, pname) in enumerate(sorted_names):
+        l = log_system.get_log_level_for_logger(name)
+        #print("{} - {}".format(pname, l))
+        sorted_names[i] = (name, pname, l)
+    return [["{}:{}".format(l[:1], pname), lambda x=name, y=l:change_loglevel(x, y)] for name, pname, l in sorted_names]
+
+def config_logging():
+    Menu([], i, o, contents_hook=get_menu_contents).activate()

--- a/apps/settings/logging_ui.py
+++ b/apps/settings/logging_ui.py
@@ -51,7 +51,7 @@ def select_loglevel(current):
     available_levels = get_available_levels()
     lb_contents = [[level.capitalize(), level] for level in available_levels]
     lb = Listbox(lb_contents, i, o, "Loglevel selection listbox")
-    lb.start_value = available_levels.index(current.lower())
+    lb.start_pointer = available_levels.index(current.lower())
     return lb.activate()
 
 def change_loglevel(logger_name, current_level):

--- a/apps/settings/logging_ui.py
+++ b/apps/settings/logging_ui.py
@@ -15,7 +15,7 @@ logger_alias_map = (("root","Main launcher"),
 
 logger_alias_map = OrderedDict(logger_alias_map)
 
-from ui import Menu, Printer, Listbox
+from ui import Menu, Listbox
 
 def get_logger_names():
     return log_system.get_logger_names()
@@ -49,8 +49,6 @@ def get_available_levels():
 
 def select_loglevel(current):
     available_levels = get_available_levels()
-    print(current)
-    print(available_levels)
     lb_contents = [[level.capitalize(), level] for level in available_levels]
     lb = Listbox(lb_contents, i, o, "Loglevel selection listbox")
     lb.start_value = available_levels.index(current.lower())
@@ -62,7 +60,6 @@ def change_loglevel(logger_name, current_level):
         assert (new_level in get_available_levels())
         log_system.LoggingConfig().set_level(logger_name, new_level)
         log_system.LoggingConfig().reload_config()
-        print("Loglevel set!")
 
 def get_menu_contents():
     logger_names = get_logger_names()
@@ -70,7 +67,6 @@ def get_menu_contents():
     sorted_names = sorted(pretty_logger_names.items(), key=lambda x: x[1])
     for i, (name, pname) in enumerate(sorted_names):
         l = log_system.get_log_level_for_logger(name)
-        #print("{} - {}".format(pname, l))
         sorted_names[i] = (name, pname, l)
     return [["{}:{}".format(l[:1], pname), lambda x=name, y=l:change_loglevel(x, y)] for name, pname, l in sorted_names]
 

--- a/apps/settings/main.py
+++ b/apps/settings/main.py
@@ -1,4 +1,3 @@
-
 import os
 import signal
 from subprocess import check_output
@@ -12,6 +11,8 @@ except:
 # Using a TextProgressBar because only it shows a message on the screen for now
 from ui import Menu, PrettyPrinter, DialogBox, TextProgressBar, Listbox
 from helpers.logger import setup_logger
+
+import logging_ui
 
 menu_name = "Settings"
 logger = setup_logger(__name__, "info")
@@ -218,19 +219,20 @@ class GitUpdater(GenericUpdater):
                 #TODO: run tests?
 
 
-def settings():
-    git_updater = GitUpdater()
-    c = [["Update ZPUI", git_updater.update],
-         ["Select branch", git_updater.pick_branch]]
-    Menu(c, i, o, "ZPUI settings menu").activate()
-
-
-callback = settings
 i = None  # Input device
 o = None  # Output device
-
 
 def init_app(input, output):
     global i, o
     i = input
     o = output
+    logging_ui.i = i
+    logging_ui.o = o
+
+def callback():
+    git_updater = GitUpdater()
+    c = [["Update ZPUI", git_updater.update],
+         ["Select branch", git_updater.pick_branch],
+         #["Submit logs", logging_ui.submit_logs],
+         ["Logging settings", logging_ui.config_logging]]
+    Menu(c, i, o, "ZPUI settings menu").activate()

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -41,6 +41,35 @@ In ``app/main.py``:
      
 ------------
 
+Add logging to your app
+-----------------------
+
+In case your application does something more complicated than printing a sentence
+on the display and exiting, you might need to add logging - so that users can then
+look through the ZPUI history, figure out what was it that went wrong, and maybe
+submit a bugreport to you!
+
+.. code-block:: python
+
+    from helpers import setup_logger # Importing the needed function
+    logger = setup_logger(__name__, "warning") # Getting a logger for your app, 
+    # default level is "warning" - this level controls logging statements that
+    # will be displayed (and saved in the logfile) by default.
+    
+    ...
+    
+    try:
+        command = "my_awesome_script"
+        logger.info("Calling the '{}' command".format(command))
+        output = call(command)
+        logger.debug("Finished executing the command")
+        for value in output.split():
+            if value not in expected_values:
+                logger.warning("Unexpected value {} found when parsing command output; proceeding".format(value))
+    except:
+        logger.exception("Exception while calling the command!")
+        # .exception will also log the details of the exception after your message
+
 Config (and other) files
 ========================
 

--- a/docs/howto.rst
+++ b/docs/howto.rst
@@ -73,8 +73,8 @@ submit a bugreport to you!
 Config (and other) files
 ========================
 
-How to get path to a file in the app directory?
------------------------------------------------
+Get path to a file in the app directory
+---------------------------------------
 
 Say, you have a ``my_song.mp3`` file shipped with your app. However, in order to use
 that file from your code, you have to refer to that file using a path relative to the
@@ -98,8 +98,8 @@ In case of your app having nested folders, you can also give multiple arguments 
 
 ------------
 
-How to read JSON from a ``config.json`` file located in the app directory?
---------------------------------------------------------------------------
+Read JSON from a ``config.json`` file located in the app directory
+------------------------------------------------------------------
 
 .. code-block:: python
 
@@ -111,8 +111,8 @@ How to read JSON from a ``config.json`` file located in the app directory?
 
 ------------
 
-How to read a ``config.json`` file, and restore it to defaults if it can't be read?
------------------------------------------------------------------------------------
+Read a ``config.json`` file, and restore it to defaults if it can't be read
+---------------------------------------------------------------------------
 
 .. code-block:: python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Guides:
 * :doc:`App development - how to ... ? <howto>`
 * :doc:`ZPUI configuration files <config>`
 * :doc:`Hacking on UI <hacking_ui>`
+* :doc:`Logging configuration <logging_config>`
 
 References:
 ===========
@@ -43,6 +44,7 @@ References:
    ui.rst
    helpers.rst
    hacking_ui.rst
+   logging.rst
    app_mgmt.rst
    docs_development.rst
    contact.rst

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,0 +1,26 @@
+.. _logging_config:
+
+Logging configuration
+#####################
+
+Changing log levels
+===================
+
+In case of problems with ZPUI, logs can help you understand it - especially when
+the problem is not easily repeatable. To enable verbose logging for a particular
+system/app/driver, go to ``"Settings"->"Logging settings"`` menu, then click on
+the part of ZPUI that you're interested in and pick "Debug". From now on, that part
+of ZPUI will log a lot more in ``zpui.log`` files - which you can then read through,
+or send to the developers.
+
+Alternatively, you can change the log_conf.ini file directly. In it, add a new
+section for the app you want to learn, like this:
+
+.. code-block:: ini
+
+    [path.to.code.file]
+    level = debug
+
+``path.to.code.file`` would be the Python-style path to the module you want to debug,
+for example, ``input.input``, ``context_manager`` or ``apps.network_apps.wpa_cli``.
+

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -15,15 +15,21 @@ except:
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
+logger_names = set()
+
 def setup_logger(logger_name, requested_level):
     # type: (str, str) -> logging.Logger
+    global logger_names
     level = check_log_level(requested_level, logging.WARNING)
     level = LoggingConfig().get_level(logger_name, level)
     logger.debug("Logger {} will be set to {} level".format(logger_name, get_log_level_name(level)))
     l = logging.getLogger(logger_name)
     l.setLevel(level)
+    logger_names.add(logger_name)
     return l
 
+def get_logger_names():
+    return list(logger_names)
 
 def check_log_level(log_level_name, default_value):
     # type: (str, int) -> int
@@ -41,11 +47,12 @@ def check_log_level(log_level_name, default_value):
     except ValueError:
         return default_value
 
+def get_log_level_for_logger(logger_name):
+    return get_log_level_name(logging.getLogger(logger_name).level)
 
 def get_log_level_name(level):
     assert(level in logging._levelNames)
     return logging._levelNames[level]
-
 
 def on_reload(*args):
     LoggingConfig().reload_config()

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -13,7 +13,7 @@ except:
 
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.WARNING)
 
 def setup_logger(logger_name, requested_level):
     # type: (str, str) -> logging.Logger

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -50,7 +50,7 @@ def on_reload(*args):
 class LoggingConfig(Singleton):
     def __init__(self):
         self.default_log_level = logging.WARNING
-        self._config_file_path = "/opt/zpui/log_conf.ini"
+        self._config_file_path = "log_conf.ini"
         self._app_overrides = {}
         self._load_config()
 

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,11 +1,24 @@
 import logging
 
-def setup_logger(logger_name, log_level="warning"):
+
+def setup_logger(logger_name, log_level):
     # type: (str, str) -> logging.Logger
-    possible_loglevels = ["notset", "debug", "info", "warning", "error", "critical"]
-    if log_level.lower() not in possible_loglevels:
-        raise ValueError("Wrong loglevel passed while creating '{}' logger: {}".format(logger_name, log_level))
-    logger_level_attr = getattr(logging, log_level.upper())
+    level = get_log_level(log_level, logging.WARNING)
     logger = logging.getLogger(logger_name)
-    logger.setLevel(logger_level_attr)
+    logger.setLevel(level)
     return logger
+
+
+def get_log_level(log_level_name, default_value):
+    # type: (str, int) -> int
+    """
+    Returns the log level based on a string name
+    >>> get_log_level("warning", logging.ERROR) == logging.WARNING
+    True
+    >>> get_log_level("warning???", logging.ERROR) == logging.ERROR
+    True
+    """
+    try:
+        return logging._checkLevel(log_level_name.upper())
+    except ValueError:
+        return default_value

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -33,7 +33,7 @@ def check_log_level(log_level_name, default_value):
 
     >>> check_log_level("warning", logging.ERROR) == logging.WARNING
     True
-    >>> check_log_level("warning???", logging.ERROR) == logging.ERROR
+    >>> check_log_level("invalid_level", logging.ERROR) == logging.ERROR
     True
     """
     try:

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -4,7 +4,7 @@ import argparse
 import logging
 import os
 
-from helpers.general import Singleton
+from general import Singleton
 
 try:
     import ConfigParser as configparser

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -1,9 +1,21 @@
+#!/bin/env python2
+
+import argparse
 import logging
+import os
+
+from helpers.general import Singleton
+
+try:
+    import ConfigParser as configparser
+except:
+    import configparser  # python3
 
 
 def setup_logger(logger_name, log_level):
     # type: (str, str) -> logging.Logger
     level = get_log_level(log_level, logging.WARNING)
+    level = LoggingConfig().get_level(logger_name, level)
     logger = logging.getLogger(logger_name)
     logger.setLevel(level)
     return logger
@@ -22,3 +34,95 @@ def get_log_level(log_level_name, default_value):
         return logging._checkLevel(log_level_name.upper())
     except ValueError:
         return default_value
+
+
+def get_log_level_name(level):
+    assert type(level) == int
+    if level in logging._levelNames:
+        return logging._levelNames[level]
+    return logging.NOTSET
+
+
+def on_signal():
+    LoggingConfig().reload_config()
+
+
+class LoggingConfig(Singleton):
+    def __init__(self):
+        self.default_log_level = logging.WARNING
+        self._config_file_path = "/opt/zpui/log_conf.ini"
+        self._app_overrides = {}
+        self._load_config()
+
+    def get_level(self, app_name, value_if_not_found=None):
+        if not value_if_not_found:
+            value_if_not_found = self.default_log_level
+        return_value = value_if_not_found
+
+        if app_name in self._app_overrides:
+            return_value = self._app_overrides[app_name]
+
+        return return_value
+
+    def set_level(self, app_name, level):
+        self._app_overrides[app_name] = get_log_level(level, logging.WARNING)
+        self._dispatch_log_levels()
+        self.save_to_config()
+
+    def _load_config(self):
+        if not os.path.exists(self._config_file_path):
+            open(self._config_file_path, 'a+').close()
+            return
+        ini_parser = configparser.ConfigParser()
+        ini_parser.read(self._config_file_path)
+
+        if ini_parser.has_section("global"):
+            level_name = ini_parser.get("global", "default_level")
+            self.default_log_level = get_log_level(level_name, logging.WARNING)
+        if ini_parser.has_section("app_override"):
+            for override in ini_parser.items("app_override"):
+                self._app_overrides[override[0]] = get_log_level(override[1], logging.NOTSET)
+
+    def reload_config(self):
+        self._load_config()
+        self._dispatch_log_levels()
+
+    def __str__(self):
+        config_str = "default log level: {}".format(logging.getLevelName(self.default_log_level))
+        if not len(self._app_overrides):
+            config_str += "\n\tConfig file absent or empty"
+        else:
+            for app_name, level in self._app_overrides.items():
+                config_str += "\n\t{} : {}".format(app_name, get_log_level_name(level))
+        return config_str
+
+    def _dispatch_log_levels(self):
+        for app_name, level in self._app_overrides.items():
+            logging.getLogger(app_name).setLevel(level)
+
+    def save_to_config(self):
+        ini_parser = configparser.ConfigParser()
+        ini_parser.add_section("app_override")
+        ini_parser.add_section("global")
+        ini_parser.set("global", "default_level", self.default_log_level)
+        for app_name, level in self._app_overrides.items():
+            ini_parser.set("app_override", app_name, get_log_level_name(level))
+        with open(self._config_file_path, 'w+') as config_file:
+            ini_parser.write(config_file)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="ZPUI logger configurator")
+    subparsers = parser.add_subparsers(dest='cmd', help="Command")
+    subparsers.add_parser('show', help="Shows the current configuration")
+    set_parser = subparsers.add_parser('set', help="Changes the log level of a given app")
+    set_parser.add_argument('--app_name', dest='app_name', type=str, required=True)
+    set_parser.add_argument('--level', dest='level', type=str, required=True)
+
+    args = parser.parse_args()
+    config = LoggingConfig()
+    if args.cmd == 'show':
+        print(config)
+
+    if args.cmd == 'set':
+        config.set_level(args.app_name, args.level)

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -129,11 +129,18 @@ class LoggingConfig(Singleton):
         return config_str
 
     def _dispatch_log_levels(self):
-        for app_name, level in self._app_overrides.items():
-            logging.getLogger(app_name).setLevel(level)
-            for h in logging.getLogger(app_name).handlers:
-                h.setLevel(level)
-
+        """
+        Actually applies the new logging levels from _app_overrides
+        to the individual loggers.
+        """
+        for app_name, new_level in self._app_overrides.items():
+            l = logging.getLogger(app_name)
+            current_level = l.getEffectiveLevel()
+            if current_level != new_level:
+                cl_name = get_log_level_name(current_level)
+                nl_name = get_log_level_name(new_level)
+                logger.info("Logger {}: current level is {}, new level is {}".format(app_name, cl_name, nl_name))
+                logging.getLogger(app_name).setLevel(new_level)
 
     def save_to_config(self):
         """

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -19,7 +19,7 @@ def setup_logger(logger_name, requested_level):
     # type: (str, str) -> logging.Logger
     level = check_log_level(requested_level, logging.WARNING)
     level = LoggingConfig().get_level(logger_name, level)
-    logger.info("Logger {} will be set to {} level".format(logger_name, get_log_level_name(level)))
+    logger.debug("Logger {} will be set to {} level".format(logger_name, get_log_level_name(level)))
     l = logging.getLogger(logger_name)
     l.setLevel(level)
     return l

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -48,9 +48,14 @@ def on_reload(*args):
 
 
 class LoggingConfig(Singleton):
-    def __init__(self):
+    """
+    Keeps track of the config file, allowing us to override logging levels,
+    as well as to change them while ZPUI is running.
+    """
+
+    def __init__(self, conf_path="log_conf.ini"):
         self.default_log_level = logging.WARNING
-        self._config_file_path = "log_conf.ini"
+        self._config_file_path = conf_path
         self._app_overrides = {}
         self._load_config()
 
@@ -121,13 +126,17 @@ class LoggingConfig(Singleton):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="ZPUI logger configurator")
     subparsers = parser.add_subparsers(dest='cmd', help="Command")
-    subparsers.add_parser('show', help="Shows the current configuration")
+    show_parser = subparsers.add_parser('show', help="Shows the current configuration")
+    show_parser.add_argument('--path', dest='path', type=str, required=False)
     set_parser = subparsers.add_parser('set', help="Changes the log level of a given app")
     set_parser.add_argument('--name', dest='app_name', type=str, required=True)
     set_parser.add_argument('--level', dest='level', type=str, required=True)
 
     args = parser.parse_args()
-    config = LoggingConfig()
+    # Using a relative path because, when name is __main__, log_conf.ini
+    # is located one directory up the tree
+    conf_path = getattr(args, "path", "../log_conf.ini")
+    config = LoggingConfig(conf_path = conf_path)
     if args.cmd == 'show':
         print(config)
 

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -14,20 +14,22 @@ except:
 
 def setup_logger(logger_name, log_level):
     # type: (str, str) -> logging.Logger
-    level = get_log_level(log_level, logging.WARNING)
+    level = check_log_level(requested_level, logging.WARNING)
     level = LoggingConfig().get_level(logger_name, level)
     logger = logging.getLogger(logger_name)
     logger.setLevel(level)
     return logger
 
 
-def get_log_level(log_level_name, default_value):
+def check_log_level(log_level_name, default_value):
     # type: (str, int) -> int
     """
-    Returns the log level based on a string name
-    >>> get_log_level("warning", logging.ERROR) == logging.WARNING
+    Verifies a logging level string - returns the requested log level
+    if the supplied log level name is valid, default_value otherwise.
+
+    >>> check_log_level("warning", logging.ERROR) == logging.WARNING
     True
-    >>> get_log_level("warning???", logging.ERROR) == logging.ERROR
+    >>> check_log_level("warning???", logging.ERROR) == logging.ERROR
     True
     """
     try:
@@ -65,7 +67,7 @@ class LoggingConfig(Singleton):
         return return_value
 
     def set_level(self, app_name, level):
-        self._app_overrides[app_name] = get_log_level(level, logging.WARNING)
+        self._app_overrides[app_name] = check_log_level(level, logging.WARNING)
         self._dispatch_log_levels()
         self.save_to_config()
 

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -65,15 +65,18 @@ class LoggingConfig(Singleton):
         self._app_overrides = {}
         self._load_config()
 
-    def get_level(self, app_name, value_if_not_found=None):
-        if not value_if_not_found:
-            value_if_not_found = self.default_log_level
-        return_value = value_if_not_found
+    def get_level(self, app_name, default_value=None):
+        """
+        Gets the recommended log level for an app, based on
+        whether it's overridden from the config file, the default level and
+        the global default level.
+        """
+        if not default_value:
+            default_value = self.default_log_level
 
-        if app_name in self._app_overrides:
-            return_value = self._app_overrides[app_name]
-
-        return return_value
+        logging_level = self._app_overrides.get(app_name, default_value)
+        logger.debug("The recommended log level for {} is {}".format(app_name, get_log_level_name(logging_level)))
+        return logging_level
 
     def set_level(self, app_name, level):
         """

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -43,7 +43,7 @@ def get_log_level_name(level):
     return logging.NOTSET
 
 
-def on_signal():
+def on_reload(*args):
     LoggingConfig().reload_config()
 
 
@@ -83,7 +83,11 @@ class LoggingConfig(Singleton):
             for override in ini_parser.items("app_override"):
                 self._app_overrides[override[0]] = get_log_level(override[1], logging.NOTSET)
 
-    def reload_config(self, signal_number=0, stack_frame=None):
+    def reload_config(self):
+        """
+        Loads the config file once again, reading and applying all config level
+        overrides found in it.
+        """
         self._load_config()
         self._dispatch_log_levels()
 

--- a/helpers/logger.py
+++ b/helpers/logger.py
@@ -39,10 +39,8 @@ def check_log_level(log_level_name, default_value):
 
 
 def get_log_level_name(level):
-    assert type(level) == int
-    if level in logging._levelNames:
-        return logging._levelNames[level]
-    return logging.NOTSET
+    assert(level in logging._levelNames)
+    return logging._levelNames[level]
 
 
 def on_reload(*args):

--- a/log_conf.ini
+++ b/log_conf.ini
@@ -1,6 +1,8 @@
-[app_override]
-emulator = DEBUG
+[input.input]
+level = debug
+
+[context_manager]
+level = debug
 
 [global]
-default_level = WARNING
-
+default_level = debug

--- a/log_conf.ini
+++ b/log_conf.ini
@@ -1,8 +1,0 @@
-[input.input]
-level = debug
-
-[context_manager]
-level = debug
-
-[global]
-default_level = debug

--- a/log_conf.ini
+++ b/log_conf.ini
@@ -1,0 +1,6 @@
+[app_override]
+emulator = DEBUG
+
+[global]
+default_level = WARNING
+

--- a/main.py
+++ b/main.py
@@ -182,7 +182,7 @@ if __name__ == '__main__':
 
     # Signal handler for debugging
     signal.signal(signal.SIGUSR1, dump_threads)
-    signal.signal(signal.SIGHUP, LoggingConfig().reload_config())
+    signal.signal(signal.SIGHUP, LoggingConfig().reload_config)
 
     # Setup argument parsing
     parser = argparse.ArgumentParser(description='ZPUI runner')

--- a/main.py
+++ b/main.py
@@ -12,10 +12,10 @@ from logging.handlers import RotatingFileHandler
 from apps.app_manager import AppManager
 from context_manager import ContextManager
 from helpers import read_config, local_path_gen
-from helpers.logger import LoggingConfig
 from input import input
 from output import output
 from ui import Printer
+import helpers.logger
 
 emulator_flag_filename = "emulator"
 local_path = local_path_gen(__name__)
@@ -182,7 +182,7 @@ if __name__ == '__main__':
 
     # Signal handler for debugging
     signal.signal(signal.SIGUSR1, dump_threads)
-    signal.signal(signal.SIGHUP, LoggingConfig().reload_config)
+    signal.signal(signal.SIGHUP, helpers.logger.on_reload)
 
     # Setup argument parsing
     parser = argparse.ArgumentParser(description='ZPUI runner')

--- a/main.py
+++ b/main.py
@@ -9,9 +9,10 @@ import threading
 import traceback
 from logging.handlers import RotatingFileHandler
 
-from context_manager import ContextManager
 from apps.app_manager import AppManager
+from context_manager import ContextManager
 from helpers import read_config, local_path_gen
+from helpers.logger import LoggingConfig
 from input import input
 from output import output
 from ui import Printer
@@ -181,6 +182,7 @@ if __name__ == '__main__':
 
     # Signal handler for debugging
     signal.signal(signal.SIGUSR1, dump_threads)
+    signal.signal(signal.SIGHUP, LoggingConfig().reload_config())
 
     # Setup argument parsing
     parser = argparse.ArgumentParser(description='ZPUI runner')

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ screen = None
 cm = None
 config = None
 config_path = None
+app_man = None
 
 def init():
     """Initialize input and output objects"""
@@ -99,6 +100,8 @@ def launch(name=None, **kwargs):
     Launches ZPUI, either in full mode or in
     single-app mode (if ``name`` kwarg is passed).
     """
+
+    global app_man
 
     i, o = init()
     appman_config = config.get("app_manager", {})

--- a/ui/base_list_ui.py
+++ b/ui/base_list_ui.py
@@ -41,6 +41,7 @@ class BaseListUIElement(object):
 
     contents = []
     pointer = 0
+    start_pointer = 0
     in_foreground = False
     name = ""
     exit_entry = ["Back", "exit"]
@@ -125,8 +126,10 @@ class BaseListUIElement(object):
     def before_activate(self):
         """Hook for child UI elements, is called each time activate() is called. 
         Is the perfect place to clear any flags that you don't want to persist 
-        between multiple activations of a single instance of an UI element."""
-        pass
+        between multiple activations of a single instance of an UI element.
+
+        For a start, resets the ``pointer`` to the ``start_pointer``."""
+        self.pointer = self.start_pointer
 
     def to_foreground(self):
         """ Is called when UI element's ``activate()`` method is used, sets flags

--- a/ui/checkbox.py
+++ b/ui/checkbox.py
@@ -67,6 +67,7 @@ class Checkbox(BaseListUIElement):
 
     def before_activate(self):
         # Clearing flags
+        BaseListUIElement.before_activate(self)
         self.accepted = False
 
     @to_be_foreground

--- a/ui/path_picker.py
+++ b/ui/path_picker.py
@@ -39,6 +39,7 @@ class PathPicker(BaseListBackgroundableUIElement):
 
     def before_activate(self):
         #Clearing flags
+        BaseListUIElement.before_activate(self)
         path_chosen = None
 
     def get_return_value(self):


### PR DESCRIPTION
# purpose
Deal with issue #40 :

Allowing to tweak logging levels from a config file and command-line

# status
Work in progress/broken

# implementation
A new singleton class `LoggingConfig` exists in `logger.py`. It's role is to read/write the config file stored in `/opt/zpui/log_conf.ini`.
A CLI app allows one to check the current config as well as to set an override for an app easily.
Sending `SIGHUP` to the main zpui thread triggers`LoggingConfig().reload_config()` that reads the config file and dispatches the new levels to all the loggers.

# issues
I've logged the behaviour of `LogginConfig._dispatch_log_levels` and it seems to be dispatching the levels correctly, but for some reason the logger continue to use the level they had when ZPUI started.
I'm blocked, please advise 
