### PR TITLE
Adding "with loading_bar.paused" construct (Issue #126)

### DIFF
--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -23,12 +23,13 @@ These classes are based on `Refresher`.
 
 
 class Paused(object):
+    """Wrapping for a `paused` context manager for loading indicators. Allows for:
 
+    with li.paused:
+        do some stuff
+    """
     def __init__(self, obj):
         self.obj = obj
-
-    def __call__(self):
-        return self
 
     def __enter__(self):
         self.obj.pause()

--- a/ui/loading_indicators.py
+++ b/ui/loading_indicators.py
@@ -22,6 +22,22 @@ These classes are based on `Refresher`.
 # ========================= abstract classes =========================
 
 
+class Paused(object):
+
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __call__(self):
+        return self
+
+    def __enter__(self):
+        self.obj.pause()
+        return self
+
+    def __exit__(self, *args):
+        self.obj.resume()
+
+
 class BaseLoadingIndicator(Refresher):
     """Abstract class for "loading indicator" elements."""
 
@@ -29,6 +45,7 @@ class BaseLoadingIndicator(Refresher):
         self._progress = 0
         Refresher.__init__(self, self.on_refresh, i, o, *args, **kwargs)
         self.t = None
+        self.paused = Paused(self)
 
     def on_refresh(self):
         pass

--- a/ui/tests/test_loading_indicators.py
+++ b/ui/tests/test_loading_indicators.py
@@ -1,0 +1,31 @@
+import unittest
+
+from mock import patch, Mock
+
+from ui.loading_indicators import BaseLoadingIndicator
+
+
+def get_mock_input():
+    return Mock()
+
+
+def get_mock_output(rows=8, cols=21):
+    m = Mock()
+    m.configure_mock(rows=rows, cols=cols, type=["char"])
+    return m
+
+
+class TestBaseLoadingIndicator(unittest.TestCase):
+
+    @patch("ui.refresher.Refresher.pause")
+    @patch("ui.refresher.Refresher.resume")
+    def test_with_paused(self, resume, pause):
+        i = get_mock_input()
+        o = get_mock_output()
+        li = BaseLoadingIndicator(i, o)
+        self.assertFalse(pause.called)
+        self.assertFalse(resume.called)
+        with li.paused():
+            self.assertTrue(pause.called)
+            self.assertFalse(resume.called)
+        self.assertTrue(resume.called)

--- a/ui/tests/test_loading_indicators.py
+++ b/ui/tests/test_loading_indicators.py
@@ -23,10 +23,8 @@ except ImportError:
     with patch('__builtin__.__import__', side_effect=import_mock):
         from ui.loading_indicators import BaseLoadingIndicator
 
-
 def get_mock_input():
     return Mock()
-
 
 def get_mock_output(rows=8, cols=21):
     m = Mock()

--- a/ui/tests/test_loading_indicators.py
+++ b/ui/tests/test_loading_indicators.py
@@ -1,8 +1,27 @@
+"""test for loading indicators"""
+import os
 import unittest
 
 from mock import patch, Mock
 
-from ui.loading_indicators import BaseLoadingIndicator
+try:
+    from ui.loading_indicators import BaseLoadingIndicator
+except ImportError:
+    print("Absolute imports failed, trying relative imports")
+    os.sys.path.append(os.path.dirname(os.path.abspath(".")))
+    # Store original __import__
+    orig_import = __import__
+
+    def import_mock(name, *args):
+        if name in ['helpers']:
+            return Mock()
+        elif name == 'ui.utils':
+            import utils
+            return utils
+        return orig_import(name, *args)
+
+    with patch('__builtin__.__import__', side_effect=import_mock):
+        from ui.loading_indicators import BaseLoadingIndicator
 
 
 def get_mock_input():
@@ -17,15 +36,19 @@ def get_mock_output(rows=8, cols=21):
 
 class TestBaseLoadingIndicator(unittest.TestCase):
 
-    @patch("ui.refresher.Refresher.pause")
-    @patch("ui.refresher.Refresher.resume")
-    def test_with_paused(self, resume, pause):
+    @patch("ui.loading_indicators.BaseLoadingIndicator.pause")
+    @patch("ui.loading_indicators.BaseLoadingIndicator.resume")
+    def test_with_loading_indicator_paused_construct(self, resume, pause):
         i = get_mock_input()
         o = get_mock_output()
         li = BaseLoadingIndicator(i, o)
         self.assertFalse(pause.called)
         self.assertFalse(resume.called)
-        with li.paused():
+        with li.paused:
             self.assertTrue(pause.called)
             self.assertFalse(resume.called)
         self.assertTrue(resume.called)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This should allow for the syntax referenced in issue #126 . Python does not allow a function to be used as a context manager, so my solution was to create an object that calls back to the `pause` and `resume` methods on the loading bar.

For my test file I did notice and attempt to replicate the try/catch ImportError block from the existing test files, but I must admit I do not understand what scenario this exception handling addresses so I am not certain I succeeded.

Let me know if you have any questions, thanks!