### PR TITLE
bug fix for i2c OLED displays

### DIFF
--- a/output/drivers/luma_driver.py
+++ b/output/drivers/luma_driver.py
@@ -63,7 +63,7 @@ class LumaScreen(GraphicalOutputDevice, CharacterOutputDevice, BacklightManager)
                 #Compatibility with older luma.oled versions
                 self.serial = spi(port=self.port, device=self.address, bcm_DC=self.gpio_dc, bcm_RST=self.gpio_rst)
         elif hw == "i2c":
-            self.port = port if port else default_i2c_port
+            self.port = port if port else self.default_i2c_port
             if isinstance(address, basestring): address = int(address, 16)
             self.address = address
             self.serial = i2c(port=self.port, address=self.address)


### PR DESCRIPTION
Was getting the error "NameError: global name 'default_i2c_port' is not defined".
Fix verified on Adafruit OLED Bonnet hardware.  